### PR TITLE
Remove trailing whitespace from jstest-core-2.

### DIFF
--- a/core/standards/scripts/jstest-core-2/DOM-regression/scripts/attrnode.js
+++ b/core/standards/scripts/jstest-core-2/DOM-regression/scripts/attrnode.js
@@ -42,18 +42,18 @@ try {
    test("Testing id attribute name 0", linkfoo[0].name, "id");
    test("Testing id attribute name 1", linkfoo[1].name, "href");
    test("Testing id attribute value 0", linkfoo[0].value, "link-foo");
-   test("Testing id attribute value 1", linkfoo[1].value, "http://www.opera.com/");  
-  
+   test("Testing id attribute value 1", linkfoo[1].value, "http://www.opera.com/");
+
    var linkfoo1 = linkfoo[0];
    var linkfoo2 = linkfoo[0];
    test("Getting the same attribute value twice returns the same value", linkfoo1 == linkfoo2, true);
-    
+
    //End new tests
-  
+
    testcase( "Node identity" );
 
    test( 'getting node twice gets same node', x == x2, true );
-   
+
    testcase( "Reading properties" );
 
    test( 'name is correct', x.name, "id" );
@@ -63,7 +63,7 @@ try {
    test( 'specified#2', v.specified, false );
    test( 'default name is correct', v.name, "shape" );
    test( 'default value is correct', v.value, "rect" );
-   
+
    testcase( "Setting the attributes of the attribute node" );
 
    x.value = "flabbergasted";
@@ -76,11 +76,11 @@ try {
 
    testcase( "Failing to set the attributes of the attribute node" );
 
-   expect_DOM_exception( 'set ownerElement#1', DOMException.NO_MODIFICATION_ALLOWED_ERR, 
+   expect_DOM_exception( 'set ownerElement#1', DOMException.NO_MODIFICATION_ALLOWED_ERR,
                          function(){x.ownerElement=bodyelt;} );
-   expect_DOM_exception( 'set name#1', DOMException.NO_MODIFICATION_ALLOWED_ERR, 
+   expect_DOM_exception( 'set name#1', DOMException.NO_MODIFICATION_ALLOWED_ERR,
                          function(){x.name="foo";} );
-   expect_DOM_exception( 'set specified#1', DOMException.NO_MODIFICATION_ALLOWED_ERR, 
+   expect_DOM_exception( 'set specified#1', DOMException.NO_MODIFICATION_ALLOWED_ERR,
                          function(){x.specified=true;} );
 
 } catch (e) { exception( e ); }

--- a/core/standards/scripts/jstest-core-2/DOM-regression/scripts/chardata.js
+++ b/core/standards/scripts/jstest-core-2/DOM-regression/scripts/chardata.js
@@ -29,7 +29,7 @@ try {
    test( "Attr #5", x.length, y.length );
    testnot( "Attr #6", x.length, foo.length );
    test( "Attr #7", the_div.firstChild.firstChild.length, 3 );
- 
+
    x.data = "new text";
    test( "Attr #8", x.data, "new text" );
    test( "Attr #9", x.length, 8 );
@@ -51,7 +51,7 @@ try {
 
    /*
      showfailure( "Attr #18", "IMPLEMENTME: Test exceptions on setting data when the node is readonly" );
-     expect_DOM_exception( "Attr #19", DOMException.NO_MODIFICATION_ALLOWED_ERR, 
+     expect_DOM_exception( "Attr #19", DOMException.NO_MODIFICATION_ALLOWED_ERR,
      function(){ x.length=0; } );
    */
 
@@ -85,13 +85,13 @@ try {
    test( "substringData #4", z.data, "undefined" );
 
    /* index out of bounds */
-   expect_DOM_exception( "substringData #5", DOMException.INDEX_SIZE_ERR, 
+   expect_DOM_exception( "substringData #5", DOMException.INDEX_SIZE_ERR,
                          function(){x.substringData( "test", 0 );} );
-   expect_DOM_exception( "substringData #6", DOMException.INDEX_SIZE_ERR, 
+   expect_DOM_exception( "substringData #6", DOMException.INDEX_SIZE_ERR,
                          function(){x.substringData( -1, 0 );} );
-   expect_DOM_exception( "substringData #7", DOMException.INDEX_SIZE_ERR, 
+   expect_DOM_exception( "substringData #7", DOMException.INDEX_SIZE_ERR,
                          function(){x.substringData( 0, -1 );} );
-   expect_DOM_exception( "substringData #8", DOMException.INDEX_SIZE_ERR, 
+   expect_DOM_exception( "substringData #8", DOMException.INDEX_SIZE_ERR,
                          function(){x.substringData( 10, 10 );} );
 
    testcase( "insertData" );
@@ -114,11 +114,11 @@ try {
    /* insert into back end */
    x.insertData( 16, "end" );
    test( "insertData #5", x.data, "starttestfoobar1end" );
-  
+
    /* index out of bounds */
-   expect_DOM_exception( "insertData #6", DOMException.INDEX_SIZE_ERR, 
+   expect_DOM_exception( "insertData #6", DOMException.INDEX_SIZE_ERR,
                          function(){x.insertData(-1,"test");} );
-   expect_DOM_exception( "insertData #7", DOMException.INDEX_SIZE_ERR, 
+   expect_DOM_exception( "insertData #7", DOMException.INDEX_SIZE_ERR,
                          function(){x.insertData(100,"test");} );
 
    testcase( "deleteData" );
@@ -137,7 +137,7 @@ try {
    /* delete from end */
    x.deleteData( 5, 10);
    test( "deleteData #4", x.data, "test1" );
-  
+
    /* nothing deleted */
    x.deleteData( 2, 0);
    test( "deleteData #5", x.data, "test1" );
@@ -145,9 +145,9 @@ try {
    test( "deleteData #6", x.data, "test1" );
 
    /* index out of bounds */
-   expect_DOM_exception( "deleteData #2", DOMException.INDEX_SIZE_ERR, 
+   expect_DOM_exception( "deleteData #2", DOMException.INDEX_SIZE_ERR,
                          function(){x.deleteData(-1,0);} );
-   expect_DOM_exception( "deleteData #3", DOMException.INDEX_SIZE_ERR, 
+   expect_DOM_exception( "deleteData #3", DOMException.INDEX_SIZE_ERR,
                          function(){x.deleteData(0,-1);} );
 
    testcase( "replaceData" );
@@ -164,27 +164,27 @@ try {
    test( "replaceData #3", y.data, "startend" );
 
    /* replace middle */
-   y.replaceData( 1, 6, "dummy" ); 
+   y.replaceData( 1, 6, "dummy" );
    test( "replaceData #4", y.data, "sdummyd" );
 
    /* replace whole string */
-   y.replaceData( 0, 10, "test2" ); 
+   y.replaceData( 0, 10, "test2" );
    test( "replaceData #5", y.data, "test2" );
 
    /* empty string */
-   y.replaceData( 0, 7, "" ); 
+   y.replaceData( 0, 7, "" );
    test( "replaceData #6", y.data, "" );
 
    /* nothing is replaced with test2 (only appended) */
-   y.replaceData( 0, 0, "test2" ); 
+   y.replaceData( 0, 0, "test2" );
    test( "replaceData #7", y.data, "test2" );
 
    /* index out of bounds */
-   expect_DOM_exception( "replaceData #8", DOMException.INDEX_SIZE_ERR, 
+   expect_DOM_exception( "replaceData #8", DOMException.INDEX_SIZE_ERR,
                          function(){x.replaceData( -1, 0, "test" );} );
-   expect_DOM_exception( "replaceData #9", DOMException.INDEX_SIZE_ERR, 
+   expect_DOM_exception( "replaceData #9", DOMException.INDEX_SIZE_ERR,
                          function(){x.replaceData( 0, -1, "test" );} );
-   expect_DOM_exception( "replaceData #10", DOMException.INDEX_SIZE_ERR, 
+   expect_DOM_exception( "replaceData #10", DOMException.INDEX_SIZE_ERR,
                          function(){x.replaceData( 30, 4,"test");} );
 
    /* check that xml parser does not split text-nodes at linebreak. */

--- a/core/standards/scripts/jstest-core-2/DOM-regression/scripts/importNode.js
+++ b/core/standards/scripts/jstest-core-2/DOM-regression/scripts/importNode.js
@@ -35,7 +35,7 @@ try {
       else
       {
         testcase("Import element node");
- 
+
         var remoteElement = d.getElementById( "span-pop-up" );
         tdef( "Element #2", remoteElement );
         var impElement = document.importNode( remoteElement, true );
@@ -64,7 +64,7 @@ try {
         localSpan.removeChild( localSpan.lastChild );
         test( "Element #18", localSpan.childNodes.length, 1 );
 
-        expect_DOM_exception( "Element #19", DOMException.WRONG_DOCUMENT_ERR, 
+        expect_DOM_exception( "Element #19", DOMException.WRONG_DOCUMENT_ERR,
                               function(){ localSpan.appendChild( remoteElement ); } );
 
         testcase("Import attribute node");
@@ -75,7 +75,7 @@ try {
         var localAttr = impElement.getAttributeNode("ID");
         tdef( "Attribute #4", localAttr );
         var remoteAttr = remoteElement.getAttributeNode("ID");
-        tdef( "Attribute #5", remoteAttr ); 
+        tdef( "Attribute #5", remoteAttr );
         var impAttr = document.importNode( remoteAttr, true );
         tdef( "Attribute #6", impAttr );
         test( "Attribute #7", impAttr.nodeType, Node.ATTRIBUTE_NODE );
@@ -100,7 +100,7 @@ try {
         test( "Attribute #22", localSpan.attributes.item(0).value, "span-pop-up" );
         test( "Attribute #23", localSpan.attributes.item(0).ownerElement, localSpan );
 
-        expect_DOM_exception( "Attribute #24", DOMException.INUSE_ATTRIBUTE_ERR, 
+        expect_DOM_exception( "Attribute #24", DOMException.INUSE_ATTRIBUTE_ERR,
                               function(){ localSpan.setAttributeNode( remoteAttr ); } );
 
         testcase("Import document fragment node");
@@ -113,10 +113,10 @@ try {
         test( "Document Fragment #3", remoteDocFrag.childNodes.length, 1 );
         test( "Document Fragment #4", remoteDocFrag.childNodes[0].firstChild.nodeValue, "A pop-up window!" );
         test( "Document Fragment #5", localSpan.childNodes.length, 1 );
-        test( "Document Fragment #6", localSpan.childNodes[0].nodeValue, "A base window!" );  
+        test( "Document Fragment #6", localSpan.childNodes[0].nodeValue, "A base window!" );
         var impDocFrag = document.importNode( remoteDocFrag, true );
         test( "Document Fragment #7", impDocFrag.nodeType, Node.DOCUMENT_FRAGMENT_NODE );
-        localSpan.appendChild( impDocFrag );  
+        localSpan.appendChild( impDocFrag );
         test( "Document Fragment #8", localSpan.childNodes.length, 2 );
         test( "Document Fragment #9", localSpan.childNodes[0].nodeValue, "A base window!" );
         test( "Document Fragment #10", localSpan.childNodes[1].firstChild.nodeValue, "A pop-up window!" );
@@ -132,7 +132,7 @@ try {
         test( "Document Fragment #16", localSpan.childNodes.length, 1 );
         test( "Document Fragment #17", localSpan.childNodes[0].nodeValue, "A base window!" );
 
-        expect_DOM_exception( "Document Fragment #18", DOMException.WRONG_DOCUMENT_ERR, 
+        expect_DOM_exception( "Document Fragment #18", DOMException.WRONG_DOCUMENT_ERR,
                               function(){ localSpan.appendChild( remoteDocFrag ); } );
 
         testcase("Import text node");
@@ -140,9 +140,9 @@ try {
         var remoteText = remoteElement.firstChild;
         tdef( "Text #1", remoteText );
         test( "Text #2", remoteText.nodeType, Node.TEXT_NODE );
-        test( "Text #3", remoteText.nodeValue, "A pop-up window!" );  
+        test( "Text #3", remoteText.nodeValue, "A pop-up window!" );
         test( "Text #4", localSpan.childNodes.length, 1 );
-        test( "Text #5", localSpan.firstChild.nodeValue, "A base window!" );  
+        test( "Text #5", localSpan.firstChild.nodeValue, "A base window!" );
         var impText = document.importNode( remoteText, true );
         test( "Text #6", impText.nodeType, Node.TEXT_NODE );
         test( "Text #7", impText.parentNode, null );
@@ -150,21 +150,21 @@ try {
         test( "Text #9", impText.data, "A pop-up window!" );
         test( "Text #10", impText.length, 16 );
         localSpan.appendChild( impText );
-        test( "Text #11", localSpan.childNodes[0].nodeValue, "A base window!" );  
-        test( "Text #12", localSpan.childNodes[1].nodeValue, "A pop-up window!" );  
+        test( "Text #11", localSpan.childNodes[0].nodeValue, "A base window!" );
+        test( "Text #12", localSpan.childNodes[1].nodeValue, "A pop-up window!" );
 
         impText = document.importNode( remoteText, false );
         test( "Text #13", impText.nodeType, Node.TEXT_NODE );
         localSpan.appendChild( impText );
-        test( "Text #14", localSpan.childNodes[0].nodeValue, "A base window!" );  
-        test( "Text #15", localSpan.childNodes[1].nodeValue, "A pop-up window!" );  
+        test( "Text #14", localSpan.childNodes[0].nodeValue, "A base window!" );
+        test( "Text #15", localSpan.childNodes[1].nodeValue, "A pop-up window!" );
 
-        expect_DOM_exception( "Text #16", DOMException.WRONG_DOCUMENT_ERR, 
+        expect_DOM_exception( "Text #16", DOMException.WRONG_DOCUMENT_ERR,
                               function(){ localSpan.appendChild( remoteText ); } );
 
         testcase("Import document node");
 
-        expect_DOM_exception( "Document #1", DOMException.NOT_SUPPORTED_ERR, 
+        expect_DOM_exception( "Document #1", DOMException.NOT_SUPPORTED_ERR,
                               function(){ document.importNode( d, true ); } );
 
         // wrong input parameters

--- a/core/standards/scripts/jstest-core-2/DOM-regression/scripts/node.js
+++ b/core/standards/scripts/jstest-core-2/DOM-regression/scripts/node.js
@@ -14,8 +14,8 @@ testcase( "Node constructor exists" );
 
   try {
     tdef( "Node", window.Node );
-  } 
-  catch (e) { 
+  }
+  catch (e) {
     exception( e );
     window.Node = function () { throw( "Do not call me!" ); }
   }
@@ -53,25 +53,25 @@ testcase( "Read-only attributes" );
 
   test( "nodeType #1", the_link.nodeType, Node.ELEMENT_NODE );
   test( "nodeType #2", the_attr.nodeType, Node.ATTRIBUTE_NODE );
-  expect_DOM_exception( "nodeType #3", DOMException.NO_MODIFICATION_ALLOWED_ERR, 
+  expect_DOM_exception( "nodeType #3", DOMException.NO_MODIFICATION_ALLOWED_ERR,
 	                function(){ the_link.nodeType=Node.ATTRIBUTE_NODE; } );
   test( "nodeType #4", document.nodeType, Node.DOCUMENT_NODE );
   test( "nodeType #5", the_frag.nodeType, Node.DOCUMENT_FRAGMENT_NODE );
-  expect_DOM_exception( "nodeType #6", DOMException.NO_MODIFICATION_ALLOWED_ERR, 
+  expect_DOM_exception( "nodeType #6", DOMException.NO_MODIFICATION_ALLOWED_ERR,
 	                function(){ the_frag.nodeType=Node.ATTRIBUTE_NODE; } );
 
   test( "parentNode #1", the_link.parentNode, the_div );
   test( "parentNode #2", the_div.parentNode, the_body );
-  expect_DOM_exception( "parentNode #3", DOMException.NO_MODIFICATION_ALLOWED_ERR, 
+  expect_DOM_exception( "parentNode #3", DOMException.NO_MODIFICATION_ALLOWED_ERR,
 	                function(){ the_link.parentNode=the_body; } );
   test( "parentNode #4", the_frag.parentNode, null );
-  expect_DOM_exception( "parentNode #5", DOMException.NO_MODIFICATION_ALLOWED_ERR, 
+  expect_DOM_exception( "parentNode #5", DOMException.NO_MODIFICATION_ALLOWED_ERR,
 	                function(){ the_frag.parentNode=the_body; } );
   test( "parentNode #6", the_attr.parentNode, null ); // regression test for bug #83652.
 
   test( "parentElement #1", the_link.parentNode, the_link.parentElement );
   test( "parentElement #2", document.firstChild.parentElement, null );
-  expect_DOM_exception( "parentElement #3", DOMException.NO_MODIFICATION_ALLOWED_ERR, 
+  expect_DOM_exception( "parentElement #3", DOMException.NO_MODIFICATION_ALLOWED_ERR,
                         function(){ the_link.parentElement=the_body; } );
 
   w = the_div.childNodes;
@@ -81,7 +81,7 @@ testcase( "Read-only attributes" );
   test( "childNodes #4", w.item(1), the_span );
   test( "childNodes #5", w[1], the_span );
   test( "childNodes #6", the_link.childNodes.length, 0 );
-  expect_DOM_exception( "childNodes #7", DOMException.NO_MODIFICATION_ALLOWED_ERR, 
+  expect_DOM_exception( "childNodes #7", DOMException.NO_MODIFICATION_ALLOWED_ERR,
 	                function(){ the_div.childNodes=new Array(); } );
   if (spoofingExplorer())
   {
@@ -105,30 +105,30 @@ testcase( "Read-only attributes" );
   var the_text = w.item(0);
   tdef( "r/o attributes #6", the_text );
   test( "parentNode #6", the_text.parentNode, the_span );
-  expect_DOM_exception( "parentNode #6", DOMException.NO_MODIFICATION_ALLOWED_ERR, 
+  expect_DOM_exception( "parentNode #6", DOMException.NO_MODIFICATION_ALLOWED_ERR,
 	                function(){ the_text.parentNode=the_body; } );
 
   test( "firstChild #1", the_div.firstChild, the_link );
   test( "firstChild #2", the_link.firstChild, null );
-  expect_DOM_exception( "firstChild #3", DOMException.NO_MODIFICATION_ALLOWED_ERR, 
+  expect_DOM_exception( "firstChild #3", DOMException.NO_MODIFICATION_ALLOWED_ERR,
 	                function(){ the_link.firstChild=null; } );
   test( "firstChild #4", the_attr.firstChild, null );
 
   test( "lastChild #1", the_div.lastChild, the_span );
   test( "lastChild #2", the_link.lastChild, null );
-  expect_DOM_exception( "lastChild #3", DOMException.NO_MODIFICATION_ALLOWED_ERR, 
+  expect_DOM_exception( "lastChild #3", DOMException.NO_MODIFICATION_ALLOWED_ERR,
 	                function(){ the_link.lastChild=null; } );
   test( "lastChild #4", the_attr.lastChild, null );
 
   test( "previousSibling #1", the_span.previousSibling, the_link );
   test( "previousSibling #2", the_link.previousSibling, null );
-  expect_DOM_exception( "previousSibling #3", DOMException.NO_MODIFICATION_ALLOWED_ERR, 
+  expect_DOM_exception( "previousSibling #3", DOMException.NO_MODIFICATION_ALLOWED_ERR,
 	                function(){ the_link.previousSibling=null; } );
   test( "previousSibling #4", the_attr.previousSibling, null );
 
   test( "nextSibling #1", the_link.nextSibling, the_span );
   test( "nextSibling #2", the_span.nextSibling, null );
-  expect_DOM_exception( "nextSibling #3", DOMException.NO_MODIFICATION_ALLOWED_ERR, 
+  expect_DOM_exception( "nextSibling #3", DOMException.NO_MODIFICATION_ALLOWED_ERR,
 	                function(){ the_link.nextSibling=null; } );
   test( "nextSibling #4", the_attr.nextSibling, null );
 
@@ -145,7 +145,7 @@ testcase( "Read-only attributes" );
   test( "attributes #9", the_nodemap.item(2).nodeType, Node.ATTRIBUTE_NODE );
   test( "attributes #10", the_nodemap.item(2).name, "SHAPE" );
   test( "attributes #11", the_nodemap.item(2).value, "rect" );
-  expect_DOM_exception( "attributes #9", DOMException.NO_MODIFICATION_ALLOWED_ERR, 
+  expect_DOM_exception( "attributes #9", DOMException.NO_MODIFICATION_ALLOWED_ERR,
 	                function(){ the_link.attributes=null; } );
   test( "attributes #12", the_attr.attributes, null );
   test( "attributes #13", document.attributes, null );
@@ -153,13 +153,13 @@ testcase( "Read-only attributes" );
   test( "attributes #15", the_text.attributes, null );
 
   test( "ownerDocument #1", the_link.ownerDocument, document );
-  expect_DOM_exception( "ownerDocument #2", DOMException.NO_MODIFICATION_ALLOWED_ERR, 
+  expect_DOM_exception( "ownerDocument #2", DOMException.NO_MODIFICATION_ALLOWED_ERR,
 	                function(){ the_link.ownerDocument=null; } );
 
   // Opera currently returns "http://www.w3.org/TR/REC-html40"
   // Mozilla returns null. Opera should return null.
   test( "namespaceURI #1", the_link.namespaceURI, null );
-  expect_DOM_exception( "namespaceURI #2", DOMException.NO_MODIFICATION_ALLOWED_ERR, 
+  expect_DOM_exception( "namespaceURI #2", DOMException.NO_MODIFICATION_ALLOWED_ERR,
 	                function(){ the_link.namespaceURI=null; } );
 
   test( "localName #1", the_link.localName, "A" );
@@ -167,7 +167,7 @@ testcase( "Read-only attributes" );
   test( "localName #3", the_div.localName, "DIV" );
   test( "localName #4", the_body.localName, "BODY" );
   test( "localName #5", the_attr.localName, "href" );
-  expect_DOM_exception( "localName #6", DOMException.NO_MODIFICATION_ALLOWED_ERR, 
+  expect_DOM_exception( "localName #6", DOMException.NO_MODIFICATION_ALLOWED_ERR,
 	                function(){ the_link.localName=null; } );
   test( "localName #7", the_frag.localName, undefined );
   test( "localName #8", the_text.localName, undefined );
@@ -178,19 +178,19 @@ testcase( "nodeName" );
   // Tests are included for Element, Attr, Text, Document, DocumentFragment
 
   test( "nodeName #1 (element)", the_link.nodeName, "A" );
-  expect_DOM_exception( "nodeName #2 (element)", DOMException.NO_MODIFICATION_ALLOWED_ERR, 
+  expect_DOM_exception( "nodeName #2 (element)", DOMException.NO_MODIFICATION_ALLOWED_ERR,
 	                function(){ the_link.nodeName="foo"; } );
   test( "nodeName #3 (attribute)", the_attr.nodeName, "href" );
-  expect_DOM_exception( "nodeName #4 (attribute)", DOMException.NO_MODIFICATION_ALLOWED_ERR, 
+  expect_DOM_exception( "nodeName #4 (attribute)", DOMException.NO_MODIFICATION_ALLOWED_ERR,
 	                function(){ the_attr.nodeName="foo"; } );
   test( "nodeName #5 (text)", the_text.nodeName, "#text" );
-  expect_DOM_exception( "nodeName #6 (text)", DOMException.NO_MODIFICATION_ALLOWED_ERR, 
+  expect_DOM_exception( "nodeName #6 (text)", DOMException.NO_MODIFICATION_ALLOWED_ERR,
 	                function(){ the_text.nodeName="foo"; } );
   test( "nodeName #7 (document)", document.nodeName, "#document" );
-  expect_DOM_exception( "nodeName #8 (document)", DOMException.NO_MODIFICATION_ALLOWED_ERR, 
+  expect_DOM_exception( "nodeName #8 (document)", DOMException.NO_MODIFICATION_ALLOWED_ERR,
 	                function(){ document.nodeName="foo"; } );
   test( "nodeName #9 (document fragment)", the_frag.nodeName, "#document-fragment" );
-  expect_DOM_exception( "nodeName #10 (document fragment)", DOMException.NO_MODIFICATION_ALLOWED_ERR, 
+  expect_DOM_exception( "nodeName #10 (document fragment)", DOMException.NO_MODIFICATION_ALLOWED_ERR,
 	                function(){ the_frag.nodeName="foo"; } );
 
 testcase( "Read-write attributes" );
@@ -198,7 +198,7 @@ testcase( "Read-write attributes" );
   // Exceptions on write: NO_MODIFICATION_ALLOWED_ERR if read-only node
   // Exceptions on read: DOMSTRING_SIZE_ERR, but cannot be triggered in Opera, we
   //   support strings up to 2^31-1 chars long, longer than available memory
-  
+
   // Exceptions on write: INVALID_CHARACTER_ERR, NO_MODIFICATION_ALLOWED_ERR (if r/o node), NAMESPACE_ERR
   test( "prefix #1", the_link.prefix, null ); 		// FIXME, nees more tests
 
@@ -240,7 +240,7 @@ testcase( "appendChild" );
 
   the_span = the_div.appendChild( the_frag.firstChild );
   tdef( "appendChild #4", the_span );
-  test( "appendChild #5", the_span.childNodes.length, 1 );  
+  test( "appendChild #5", the_span.childNodes.length, 1 );
   test( "appendChild #6", the_span.childNodes.item(0).nodeValue, "A span!" );
   test( "appendChild #7", the_div.lastChild, the_span );
   test( "appendChild #8", the_div.lastChild.localName, "SPAN" );
@@ -303,13 +303,13 @@ testcase( "appendChild" );
   the_div.appendChild();
 
   // exception tests
-  expect_DOM_exception( "appendChild #44", DOMException.HIERARCHY_REQUEST_ERR, 
+  expect_DOM_exception( "appendChild #44", DOMException.HIERARCHY_REQUEST_ERR,
 	                function(){ the_link.appendChild( the_body ); } );
 
-  expect_DOM_exception( "appendChild #45", DOMException.HIERARCHY_REQUEST_ERR, 
+  expect_DOM_exception( "appendChild #45", DOMException.HIERARCHY_REQUEST_ERR,
 				function(){ the_div.appendChild( the_span.attributes.item(0) ); } );
 
-  expect_DOM_exception( "appendChild #46", DOMException.HIERARCHY_REQUEST_ERR, 
+  expect_DOM_exception( "appendChild #46", DOMException.HIERARCHY_REQUEST_ERR,
 				function(){ the_frag.appendChild( the_span.attributes.item(0) ); } );
 
   // regression test for bug #83666.
@@ -562,13 +562,13 @@ testcase( "insertBefore" );
   the_div.insertBefore( the_clone );
 
   // exception tests
-  expect_DOM_exception( "insertBefore #69", undefined, 
+  expect_DOM_exception( "insertBefore #69", undefined,
 	                  function(){ the_frag.firstChild.insertBefore( the_frag.lastChild, the_div.lastChild ); } );
 
-  expect_DOM_exception( "insertBefore #70", DOMException.HIERARCHY_REQUEST_ERR, 
+  expect_DOM_exception( "insertBefore #70", DOMException.HIERARCHY_REQUEST_ERR,
 	                  function(){ the_div.firstChild.insertBefore( the_div, the_div.lastChild ); } );
 
-  expect_DOM_exception( "insertBefore #71", DOMException.NOT_FOUND_ERR, 
+  expect_DOM_exception( "insertBefore #71", DOMException.NOT_FOUND_ERR,
 	                  function(){ the_div.childNodes.item(2).insertBefore( the_div.childNodes.item(2).firstChild, the_div.childNodes.item(5).firstChild ); } );
 
   // now insert two clone elements (with child elements) into the_frag and check exceptions
@@ -585,28 +585,28 @@ testcase( "insertBefore" );
   tdef( "insertBefore #79", the_frag.childNodes );
   test( "insertBefore #80", the_frag.childNodes.length, 2 );
 
-  expect_DOM_exception( "insertBefore #81", DOMException.HIERARCHY_REQUEST_ERR, 
+  expect_DOM_exception( "insertBefore #81", DOMException.HIERARCHY_REQUEST_ERR,
 	                  function(){ the_frag.firstChild.insertBefore( the_frag, the_frag.lastChild ); } );
 
-  expect_DOM_exception( "insertBefore #82", DOMException.NOT_FOUND_ERR, 
+  expect_DOM_exception( "insertBefore #82", DOMException.NOT_FOUND_ERR,
 	                  function(){ the_frag.childNodes.item(0).insertBefore( the_frag.childNodes.item(0).firstChild, the_frag.childNodes.item(1).firstChild ); } );
 
-  expect_DOM_exception( "insertBefore #83", DOMException.NOT_FOUND_ERR, 
+  expect_DOM_exception( "insertBefore #83", DOMException.NOT_FOUND_ERR,
 	                  function(){ the_div.insertBefore( the_frag.firstChild, the_frag.lastChild ); } );
 
-  expect_DOM_exception( "insertBefore #84", DOMException.NOT_FOUND_ERR, 
+  expect_DOM_exception( "insertBefore #84", DOMException.NOT_FOUND_ERR,
 	                  function(){ the_div.insertBefore( the_frag.firstChild, the_frag ); } );
 
   expect_DOM_exception( "insertBefore #85", DOMException.HIERARCHY_REQUEST_ERR,
 				function(){ the_div.insertBefore( the_span.attributes.item(0), the_div.attributes.item(0) ); } );
 
-  expect_DOM_exception( "insertBefore #86", DOMException.HIERARCHY_REQUEST_ERR, 
+  expect_DOM_exception( "insertBefore #86", DOMException.HIERARCHY_REQUEST_ERR,
 				function(){ the_div.insertBefore( the_span.attributes.item(0), null ); } );
 
-  expect_DOM_exception( "insertBefore #87", DOMException.NOT_FOUND_ERR, 
+  expect_DOM_exception( "insertBefore #87", DOMException.NOT_FOUND_ERR,
 				function(){ the_div.insertBefore( the_span, the_div.attributes.item(0) ); } );
 
-  expect_DOM_exception( "insertBefore #88", DOMException.HIERARCHY_REQUEST_ERR, 
+  expect_DOM_exception( "insertBefore #88", DOMException.HIERARCHY_REQUEST_ERR,
 				function(){ the_frag.insertBefore( the_span.attributes.item(0), null ); } );
 
 testcase( "removeChild" );
@@ -641,16 +641,16 @@ testcase( "removeChild" );
   the_div.removeChild();
 
   // exception tests
-  expect_DOM_exception( "removeChild #14", DOMException.NOT_FOUND_ERR, 
+  expect_DOM_exception( "removeChild #14", DOMException.NOT_FOUND_ERR,
 				function(){ the_div.removeChild( the_div.firstChild.attributes.item(0) ); } );
 
-  expect_DOM_exception( "removeChild #15", DOMException.NOT_FOUND_ERR, 
+  expect_DOM_exception( "removeChild #15", DOMException.NOT_FOUND_ERR,
 				function(){ the_frag.removeChild( the_frag.firstChild.attributes.item(0) ); } );
 
-  expect_DOM_exception( "removeChild #16", DOMException.NOT_FOUND_ERR, 
+  expect_DOM_exception( "removeChild #16", DOMException.NOT_FOUND_ERR,
 				function(){ the_div.removeChild( the_frag ); } );
 
-  expect_DOM_exception( "removeChild #17", DOMException.NOT_FOUND_ERR, 
+  expect_DOM_exception( "removeChild #17", DOMException.NOT_FOUND_ERR,
 				function(){ the_span.removeChild( the_div ); } );
 
 testcase( "isSupported" );
@@ -726,7 +726,7 @@ testcase( "replaceChild" );
   tmp = the_frag.replaceChild( null, null );
 
   test( "replaceChild #28", the_link.hasChildNodes(), false );
-  tmp = the_link.replaceChild( the_span.childNodes.firstChild, the_span ); 
+  tmp = the_link.replaceChild( the_span.childNodes.firstChild, the_span );
   test( "replaceChild #29", the_link.hasChildNodes(), false );
 
   tdef( "replaceChild #30", the_frag );
@@ -747,13 +747,13 @@ testcase( "replaceChild" );
   test( "replaceChild #34", divelm.firstChild.nodeValue, "Replaced" );
 
   // exception tests
-  expect_DOM_exception( "replaceChild #35", undefined, 
+  expect_DOM_exception( "replaceChild #35", undefined,
 	                  function(){ the_frag.firstChild.replaceChild( the_div.firstChild, the_frag.firstChild ); } );
 
-  expect_DOM_exception( "replaceChild #36", DOMException.HIERARCHY_REQUEST_ERR, 
+  expect_DOM_exception( "replaceChild #36", DOMException.HIERARCHY_REQUEST_ERR,
 	                  function(){ the_div.firstChild.replaceChild( the_div, the_div.lastChild ); } );
 
-  expect_DOM_exception( "replaceChild #37", DOMException.NOT_FOUND_ERR, 
+  expect_DOM_exception( "replaceChild #37", DOMException.NOT_FOUND_ERR,
 	                  function(){ the_clone.childNodes.item(1).insertBefore( the_clone.childNodes.item(1).childNodes.item(0), the_clone.childNodes.item(1) ); } );
 
 testcase( "normalize" );
@@ -831,7 +831,7 @@ testcase( "MSIE compatibility" );
     test( "all #8", the_div.all(1), the_span );
     // MSIE online docs imply that 'all' is read-only
     // See comments in DOM_Node::PutName for an explanation of why this test fails
-    expect_DOM_exception( "all #9", DOMException.NO_MODIFICATION_ALLOWED_ERR, 
+    expect_DOM_exception( "all #9", DOMException.NO_MODIFICATION_ALLOWED_ERR,
 	                  function(){ the_div.all=new Array(); }, 'Expected to fail - see comments in test script.' );
 
     tdef( "children #1", the_div.children );
@@ -844,12 +844,12 @@ testcase( "MSIE compatibility" );
     test( "children #8", the_div.children(1), the_span );
     // MSIE online docs imply that 'children' is read-only
     // See comments in DOM_Node::PutName for an explanation of why this test fails
-    expect_DOM_exception( "children #9", DOMException.NO_MODIFICATION_ALLOWED_ERR, 
+    expect_DOM_exception( "children #9", DOMException.NO_MODIFICATION_ALLOWED_ERR,
 	                  function(){ the_div.children=new Array(); }, 'Expected to fail - see comments in test script.' );
 
     tdef( "document #1", the_div.document );
     test( "document #2", the_div.document, the_div.ownerDocument );
-    expect_DOM_exception( "document #3", DOMException.NO_MODIFICATION_ALLOWED_ERR, 
+    expect_DOM_exception( "document #3", DOMException.NO_MODIFICATION_ALLOWED_ERR,
 	                  function(){ the_link.document=null; } );
   }
 

--- a/core/standards/scripts/jstest-core-2/HTML/scripts/htmlanchorelement.js
+++ b/core/standards/scripts/jstest-core-2/HTML/scripts/htmlanchorelement.js
@@ -12,11 +12,11 @@ try {
   var form2 = document.getElementById("myForm2");
   var inp1  = document.getElementById("myAnchor");
   var inp2  = document.getElementById("myAnchor2");
-  
-  
+
+
   testcase( "properties exists" );
   var inp = inp1;
-  
+
   if(is_phase(1))
   {
     tdef("href",inp.href);
@@ -35,10 +35,10 @@ try {
     tdef("tabIndex",inp.tabIndex);
     tdef("type",inp.type);
   }
-  
+
   testcase( "read property values" );
   inp = inp1;
-  
+
   if(is_phase(1))
   {
     test("href",inp.href,"");
@@ -60,7 +60,7 @@ try {
 
   testcase( "properties exists, attributes in use" );
   var inp = inp2;
-  
+
   if(is_phase(1))
   {
     tdef("href",inp.href);
@@ -82,7 +82,7 @@ try {
 
   testcase( "read property values from attributes" );
   inp = inp2;
-  
+
   if(is_phase(1))
   {
     test("href",inp.href,get_protocol_and_host() + get_modulepath("HTML","link.html"));
@@ -104,7 +104,7 @@ try {
 
   testcase( "properties are writeable" );
   inp = inp2;
-  
+
   if(is_phase(1))
   {
     inp.href = "ref.html";
@@ -123,7 +123,7 @@ try {
     inp.accessKey = "R";
     test("accessKey",inp.accessKey,"R");
     inp.tabIndex = 13;
-    test("tabIndex",inp.tabIndex,13); 
+    test("tabIndex",inp.tabIndex,13);
     inp.type = "multipart/mixed";
     test("type",inp.type,"multipart/mixed");
 
@@ -139,7 +139,7 @@ try {
 
   testcase( "properties are not writeable" );
 
-  // No readonly properties    
+  // No readonly properties
 	
   testcase( "methods exist" );
 
@@ -150,7 +150,7 @@ try {
   }
 
   testcase( "methods" );
-  
+
   if(is_phase(1))
   {
     inp.focus();
@@ -158,7 +158,7 @@ try {
     inp.blur();
     test("blur",test_call(),"call_off");
   }
-    
+
 } catch (e) { exception(e); }
 
 

--- a/core/standards/scripts/jstest-core-2/HTML/scripts/htmlappletelement.js
+++ b/core/standards/scripts/jstest-core-2/HTML/scripts/htmlappletelement.js
@@ -14,8 +14,8 @@ function go()
       var o1 = document.getElementById("myApplet1");
       var o2 = document.getElementById("myApplet2");
       var o3 = document.getElementById("myApplet3");
-      var o = o1; 
-  
+      var o = o1;
+
       tdef("align",o.align);
       tdef("alt",o.alt);
       tdef("archive",o.archive);
@@ -27,10 +27,10 @@ function go()
       tdef("object",o.object);
       tdef("vspace",o.vspace);
       tdef("width",o.width);
-  
-      var o = o1; 
+
+      var o = o1;
       testcase( "default property values" );
-  
+
       test("align",o.align,"");
       test("alt",o.alt,"");
       test("archive",o.archive,"");
@@ -42,10 +42,10 @@ function go()
       test("object",o.object,"");
       test("vspace",o.vspace,"");
       test("width",o.width,"");
- 
+
       o = o2;
       testcase( "property values from attributes" );
-  
+
       test("align",o.align,"right");
       test("alt",o.alt,"alt");
       test("archive",o.archive,"http://www.opera.com/ http://www.opera.no/");
@@ -58,7 +58,7 @@ function go()
       test("vspace",o.vspace,"7");
       test("width",o.width,"100");
 
-  
+
       if(is_phase(2)) // All attributes currently readonly
       {
          testcase( "properties are writable" );
@@ -67,7 +67,7 @@ function go()
       if (navigator.javaEnabled())
       {
         o = o2;
-        testcase( "random attributes" ); 
+        testcase( "random attributes" );
         // Attributes defined by the applet itself. Accessible through liveconnect.
         // Note that if the applet has an attribute with a name that is identical
         // to an attribute of the HTMLAppletElement, ie. "code", the internal
@@ -76,7 +76,7 @@ function go()
         test("code",o.code,"Helleu");
         test("nummer",o.nummer,0);
       }
-  
+
    } catch (e) { exception(e); }
 
    testmodule_finished();

--- a/core/standards/scripts/jstest-core-2/HTML/scripts/htmlbodyelement.js
+++ b/core/standards/scripts/jstest-core-2/HTML/scripts/htmlbodyelement.js
@@ -13,9 +13,9 @@ try {
   testcase( "object" );
 
   test("class",b,"[object HTMLBodyElement]");
-   
+
   testcase( "properties exists" );
-  
+
   tdef("aLink",b.aLink);
   tdef("background",b.background);
   tdef("bgColor",b.bgColor);
@@ -25,12 +25,12 @@ try {
 
 /*
   testcase( "property types" );
-  
+
   testinstance("aLink" ,b.aLink, HTMLBodyElement); // ???
 */
-  
+
   testcase( "property values" );
-  
+
   test("aLink",b.aLink,"");
   test("background",b.background,"");
   test("bgColor",b.bgColor,"");
@@ -40,7 +40,7 @@ try {
 
 
   testcase( "properties are writable" );
-  
+
   b.aLink = "pink";
   test("aLink",b.aLink,"pink");
   b.background = "image2";

--- a/core/standards/scripts/jstest-core-2/HTML/scripts/htmlbuttonelement.js
+++ b/core/standards/scripts/jstest-core-2/HTML/scripts/htmlbuttonelement.js
@@ -12,7 +12,7 @@ try {
 	testcase( "object" );
 
 	test("class",b1,"[object HTMLButtonElement]");
-  
+
 	testcase( "attribute object class" );
 
 	test("form",b1.form,"[object HTMLFormElement]");

--- a/core/standards/scripts/jstest-core-2/HTML/scripts/htmlcollection.js
+++ b/core/standards/scripts/jstest-core-2/HTML/scripts/htmlcollection.js
@@ -11,23 +11,23 @@ try {
   var c = document.images;
   var i1 =  document.getElementById ("img1");
   var i2 =  document.getElementById ("img2");
-   
+
   testcase( "object" );
 
   test("class",c,"[object HTMLCollection]");
 
   testcase( "properties exists" );
-  
+
   tdef("length",c.length);
 
 /*
   testcase( "property types" );
-  
+
   testinstance("body" ,c.body, HTMLElement); // ???
 */
 
   testcase( "property values" );
-  
+
   test("length",c.length,2);
 
   testcase( "properties are not writeable" );
@@ -36,31 +36,31 @@ try {
   test("length",c.length,2);
 
   testcase( "methods exist" );
- 
+
   tdef("item",c.item);
   tdef("namedItem",c.namedItem);
 
   testcase( "methods" );
-  
+
   var i = c.item(0);
   test("item(0)",i,i1);
-  
+
   i = c.item(1);
   test("item(1)",i,i2);
-  
+
   i = c.namedItem("img1");
   test("namedItem(name)",i,i1);
 
   i = c.namedItem("img2");
   test("namedItem(id)",i,i2);
-  
+
   test("item equals namedItem",c.item(0),c.namedItem("img1"));
   test("item equals namedItem",c.item(1),c.namedItem("img2"));
   test("[]",c[0],i1);
   test("[]",c[1],i2);
   test("[name]",c["img1"],i1);
   test("[name]",c["img2"],i2);
-  
+
 } catch (e) { exception(e); }
 
 testmodule_finished();

--- a/core/standards/scripts/jstest-core-2/HTML/scripts/htmlfieldsetelement.js
+++ b/core/standards/scripts/jstest-core-2/HTML/scripts/htmlfieldsetelement.js
@@ -13,7 +13,7 @@ try {
 	testcase( "object" );
 
 	test("class",f1,"[object HTMLFieldSetElement]");
-  
+
 	testcase( "attribute object class" );
 
 	test("form",f1.form,"[object HTMLFormElement]");

--- a/core/standards/scripts/jstest-core-2/HTML/scripts/htmlformelement.js
+++ b/core/standards/scripts/jstest-core-2/HTML/scripts/htmlformelement.js
@@ -9,17 +9,17 @@ testmodule( "HTMLFormElement", cvs );
 try {
 
   var f = document.getElementById("myForm");
-   
+
   testcase( "object" );
 
   test("class",f,"[object HTMLFormElement]");
-  
+
   testcase( "attribute object class" );
 
   test("elements",f.elements,"[object HTMLCollection]");
 
   testcase( "properties exists" );
-  
+
   tdef("acceptCharset",f.acceptCharset);
   tdef("action",f.action);
   tdef("elements",f.elements);
@@ -28,15 +28,15 @@ try {
   tdef("method",f.method);
   tdef("name",f.name);
   tdef("target",f.target);
- 
+
 /*
   testcase( "property types" );
-  
+
   testinstance("acceptCharset" ,f.aLink, HTMLBodyElement); // ???
 */
 
   testcase( "read property values" );
-  
+
   test("acceptCharset",f.acceptCharset,"");
   test("action",f.action,"");
   test("enctype",f.enctype,"application/x-www-form-urlencoded");
@@ -45,11 +45,11 @@ try {
   test("name",f.name,"");
   test("target",f.target,"");
   test("elements",f.elements.length,7);
-  
+
 
   f = document.getElementById("myForm2");
   testcase( "properties exists, attributes in use" );
-  
+
   tdef("acceptCharset",f.acceptCharset);
   tdef("action",f.action);
   tdef("elements",f.elements);
@@ -58,10 +58,10 @@ try {
   tdef("method",f.method);
   tdef("name",f.name);
   tdef("target",f.target);
- 
+
 
   testcase( "read property values from attributes" );
-  
+
   test("acceptCharset",f.acceptCharset,"utf-8");
   test("action",f.action,get_protocol_and_host() + get_modulepath("HTML","gogo"));
   test_insensitive("enctype",f.enctype,"multipart/form-data");
@@ -70,18 +70,18 @@ try {
   test("name",f.name,"f2");
   test("target",f.target,"");
   test("elements",f.elements.length,1);
-  
+
 
   f = document.getElementById("myForm");
   testcase( "properties are writeable" );
-  
+
   f.acceptCharset = "iso-8859-1";
   f.action  = "doIt";
   var enctype = "multipart/form-data"; f.enctype = enctype;
   f.method  = "post";
   f.name    = "f1";
   f.target  = "t1";
-  
+
   test("acceptCharset",f.acceptCharset,"iso-8859-1");
   test("action",f.action,get_protocol_and_host() + get_modulepath("HTML","doIt"));
   test_insensitive("enctype",f.enctype,enctype);
@@ -93,13 +93,13 @@ try {
 
   expect_DOM_exception( "length", DOMException.NO_MODIFICATION_ALLOWED_ERR, function(){f.length = 3;})
   test("length",f.length,7);
-  var el = f.elements; 
+  var el = f.elements;
   expect_DOM_exception( "elements", DOMException.NO_MODIFICATION_ALLOWED_ERR, function(){f.elements = null;})
   test("elements",f.elements, el);
   test("elements[0]",f.elements[0], el[0]);
   expect_DOM_exception( "elements", DOMException.NO_MODIFICATION_ALLOWED_ERR, function(){f.elements = "illegal change";})
   test("elements",f.elements, el);
-  
+
   testcase( "methods" );
 
   /*
@@ -124,13 +124,13 @@ try {
   val = h.value; h.value = "changed";
   f.reset();
   test("reset() 4 textarea",h.value, val);
-  
+
   h = document.getElementById("h5")
   val = h.value; h.value = "pilt";
   f.reset();
   test("reset() 5 select",h.value, val);
-  
-  
+
+
   // Needs server to test submit
 
 } catch (e) { exception(e); }

--- a/core/standards/scripts/jstest-core-2/HTML/scripts/htmlframeelement_int.js
+++ b/core/standards/scripts/jstest-core-2/HTML/scripts/htmlframeelement_int.js
@@ -18,9 +18,9 @@ try {
   tdef("name",p.name);
   tdef("noResize",p.noResize);
   tdef("scrolling",p.scrolling);
-  tdef("src",p.src);  
+  tdef("src",p.src);
   tdef("contentDocument",p.contentDocument);
-  
+
   testcase( "readable attribute values" );
 
   test("frameBorder",p.frameBorder,"0");
@@ -33,8 +33,8 @@ try {
   test("src",p.src,get_protocol_and_host() + get_modulepath("HTML","HTMLFrameElement2_int.html"));
 
   testcase( "properties are writable" );
-  
-  if(is_phase(2)) 
+
+  if(is_phase(2))
   {
 	p.frameBorder = "1";
 	test("reflow #1", p.frameBorder, "1");

--- a/core/standards/scripts/jstest-core-2/HTML/scripts/htmliframeelement.js
+++ b/core/standards/scripts/jstest-core-2/HTML/scripts/htmliframeelement.js
@@ -9,12 +9,12 @@ try {
 
   var p1 = document.getElementById("myIFrame");
   var p2 = document.getElementById("myIFrame2");
-  var p = p1; 
+  var p = p1;
 
   testcase( "object" );
 
   test("class",p,"[object HTMLIFrameElement]");
-  
+
   testcase( "properties exists" );
 
   tdef("align",p.align);
@@ -27,12 +27,12 @@ try {
   tdef("src",p.src);
   tdef("height",p.height);
   tdef("width",p.width);
-  
+
   tdef("contentDocument",p.contentDocument);
 
-  var p = p1; 
+  var p = p1;
   testcase( "default property values" );
-  
+
   test("align",p.align,"");
   test("frameBorder",p.frameBorder,"1");
   test("longDesc",p.longDesc,"");
@@ -47,7 +47,7 @@ try {
 
   p = p2;
   testcase( "property values from attributes" );
-  
+
   test("align",p.align,"right");
   test("frameBorder",p.frameBorder,"0");
   test("longDesc",p.longDesc,get_protocol_and_host() + get_modulepath("HTML","foo.html"));
@@ -60,17 +60,17 @@ try {
   test("height",p.height,"100");
   testnot("contentDocument",p.contentDocument,document);
   testnot("contentDocument",p.contentDocument,p1.contentDocument);
- 
+
   p = p1;
   testcase( "properties are writable" );
-  
+
   p.src = "HTMLIFrameElement3.html";
   test("src",p.src,get_protocol_and_host() + get_modulepath("HTML","HTMLIFrameElement3.html"));
 
   if(is_phase(2)) // All other attributes currently readonly
   {
   }
-  
+
   p = p2;
   testcase( "properties are not writeable" );
 

--- a/core/standards/scripts/jstest-core-2/HTML/scripts/htmlinputelement.js
+++ b/core/standards/scripts/jstest-core-2/HTML/scripts/htmlinputelement.js
@@ -14,18 +14,18 @@ try {
   var inp2  = document.getElementById("myInput2");
   var inp3  = document.getElementById("myInput3");
   var inp4  = document.getElementById("myInput4");
-  
+
   testcase( "object" );
 
   test("class",inp1,"[object HTMLInputElement]");
-  
+
   testcase( "attribute object class" );
 
   test("form",inp1.form,"[object HTMLFormElement]");
-    
+
   testcase( "properties exists" );
   var inp = inp1;
-  
+
   tdef("defaultValue",inp.defaultValue);
   tdef("defaultChecked",inp.defaultChecked);
   tdef("form",inp.form);
@@ -44,10 +44,10 @@ try {
   tdef("type",inp.type);
   tdef("useMap",inp.useMap);
   tdef("value",inp.value);
-  
+
   testcase( "read property values" );
   inp = inp1;
-  
+
   test("defaultValue",inp.defaultValue,"");
   test("defaultChecked",inp.defaultChecked,false);
   test("form",inp.form,form);
@@ -67,11 +67,11 @@ try {
   test("type",inp.type,"text");
   test("useMap",inp.useMap,"");
   test("value",inp.value,"");
-  
+
 
   testcase( "properties exists, attributes in use" );
   var inp = inp2;
-  
+
   tdef("defaultValue",inp.defaultValue);
   tdef("defaultChecked",inp.defaultChecked);
   tdef("form",inp.form);
@@ -93,7 +93,7 @@ try {
 
   testcase( "read property values from attributes" );
   inp = inp2;
-  
+
   test("defaultValue",inp.defaultValue,"verdi");
   test("defaultChecked",inp.defaultChecked,false);
   test("form",inp.form,form);
@@ -104,7 +104,7 @@ try {
   test("checked",inp.checked,false);
   ttrue("checked",inp3.checked);
   test("disabled",inp.disabled,true);
-  test("maxLength",inp.maxLength,10);  
+  test("maxLength",inp.maxLength,10);
   test("name",inp.name,"navn");
   test("readOnly",inp.readOnly,true);
   test("size",inp.size,5);
@@ -121,7 +121,7 @@ try {
 
   testcase( "properties are writeable" );
   inp = inp2;
-  
+
   inp.defaultValue = "endring";
   test("defaultValue",inp.defaultValue,"endring");
   inp3.defaultChecked = false;
@@ -141,7 +141,7 @@ try {
   inp.disabled = false;
   test("disabled",inp.disabled,false);
   inp.maxLength = 13;
-  test("maxLength",inp.maxLength,13); 
+  test("maxLength",inp.maxLength,13);
   inp.name = "felt";
   test("name",inp.name,"felt");
   inp.readOnly = false;
@@ -176,7 +176,7 @@ try {
 
   expect_DOM_exception( "form", DOMException.NO_MODIFICATION_ALLOWED_ERR, function(){inp.form = null;} )
   test("form",inp.form,form);
-    
+
 	
   testcase( "methods exist" );
 
@@ -187,7 +187,7 @@ try {
 
 
   testcase( "methods" );
-  
+
   inp3.focus();
   test("focus()",test_call(),"call_on");
   inp3.blur();
@@ -196,11 +196,11 @@ try {
   var stat = inp3.checked;
   inp3.click();
   test("click()",!inp3.checked,stat);
-  
+
   forget_call();
   inp2.select();
   test("select()",test_call(),"call_on");
-    
+
 } catch (e) { exception(e); }
 
 

--- a/core/standards/scripts/jstest-core-2/HTML/scripts/htmllabelelement.js
+++ b/core/standards/scripts/jstest-core-2/HTML/scripts/htmllabelelement.js
@@ -14,7 +14,7 @@ try {
 	testcase( "object" );
 
 	test("class",l1,"[object HTMLLabelElement]");
-  
+
 	testcase( "attribute object class" );
 
 	test("form",l1.form,"[object HTMLFormElement]");
@@ -139,7 +139,7 @@ testmodule_finished();
 function testPopup()
 {
 	testmodule( "HTMLLabelElement", cvs );
-	try 
+	try
 	{
 		testcase("Writable htmlFor");
 

--- a/core/standards/scripts/jstest-core-2/HTML/scripts/htmllegendelement.js
+++ b/core/standards/scripts/jstest-core-2/HTML/scripts/htmllegendelement.js
@@ -12,7 +12,7 @@ try {
 	testcase( "object" );
 
 	test("class",l1,"[object HTMLLegendElement]");
-  
+
 	testcase( "attribute object class" );
 
 	test("form",l1.form,"[object HTMLFormElement]");

--- a/core/standards/scripts/jstest-core-2/HTML/scripts/htmlmapelement.js
+++ b/core/standards/scripts/jstest-core-2/HTML/scripts/htmlmapelement.js
@@ -15,12 +15,12 @@ try {
 
   var o1 = document.getElementById("myMap");
   var o2 = document.getElementById("myMap2");
-  var o = o1; 
+  var o = o1;
 
   testcase( "object" );
 
   test("class",o,"[object HTMLMapElement]");
-  
+
   testcase( "attribute object class" );
 
   test("areas",o.areas,"[object HTMLCollection]");
@@ -29,37 +29,37 @@ try {
 
   tdef("areas",o.areas);
   tdef("name",o.name);
-  
-  var o = o1; 
+
+  var o = o1;
   testcase( "default property values" );
-  
+
   testOut(isCollection(o.areas), "areas is a collection");
   if(isCollection(o.areas)) test("areas",o.areas.length,0);
   test("name",o.name,"");
-  
+
 
   o = o2;
   testcase( "property values from attributes" );
-  
+
   testOut(isCollection(o.areas), "areas is a collection");
-  if(isCollection(o.areas)) 
+  if(isCollection(o.areas))
   {
     test("areas",o.areas.length,2);
     test("areas",o.areas[0].href,"http://www.opera.com/");
     test("areas",o.areas[0].accessKey,"a");
   }
   test("name",o.name,"map");
- 
+
   o = o1;
   testcase( "properties are writable" );
-  
+
   if(is_phase(2)) // All attributes currently readonly
   {
     o.name = "firstMap";
     test("name property", o.name, "firstMap");
     test("name attribute", o.getAttribute("name"), "firstMap");
   }
-  
+
   testcase( "properties are not writeable" );
 
   var ar = o.areas;

--- a/core/standards/scripts/jstest-core-2/HTML/scripts/htmloptionelement.js
+++ b/core/standards/scripts/jstest-core-2/HTML/scripts/htmloptionelement.js
@@ -17,13 +17,13 @@ try {
   testcase( "object" );
 
   test("class",opt,"[object HTMLOptionElement]");
-  
+
   testcase( "attribute object class" );
 
   test("form",opt.form,"[object HTMLFormElement]");
 
   testcase( "properties exists" );
-  
+
   tdef("form",opt.form);
   tdef("defaultSelected",opt.defaultSelected);
   tdef("text",opt.text);
@@ -32,9 +32,9 @@ try {
   tdef("label",opt.label);
   tdef("selected",opt.selected);
   tdef("value",opt.value);
-  
+
   testcase( "read property values" );
-  
+
   test("form",opt.form,form);
   test("defaultSelected",opt.defaultSelected,false);
   test("text",opt.text,"");
@@ -43,10 +43,10 @@ try {
   test("label",opt.label,"");
   test("selected",opt.selected,false);
   test("value",opt.value,"");
-  
+
 
   testcase( "properties exists, attributes in use" );
-  
+
   tdef("form",opt2.form);
   tdef("defaultSelected",opt2.defaultSelected);
   tdef("text",opt2.text);
@@ -57,7 +57,7 @@ try {
   tdef("value",opt2.value);
 
   testcase( "read property values from attributes" );
-  
+
   test("form",opt2.form,form);
   test("defaultSelected",opt2.defaultSelected,true);
   test("text",opt2.text,"der");
@@ -68,7 +68,7 @@ try {
   test("value",opt2.value,"her");
 
   testcase( "properties are writeable" );
-  
+
   opt.defaultSelected = true;
   test("defaultSelected",opt.defaultSelected,true);
   opt.disabled = true;
@@ -84,19 +84,19 @@ testcase( "properties are not writeable" );
 
 expect_DOM_exception( "form", DOMException.NO_MODIFICATION_ALLOWED_ERR, function(){opt.form = null;} )
 test("form",opt.form,form);
-/* text: DOM2 says modification isn't allowed, but people probably assume it 
+/* text: DOM2 says modification isn't allowed, but people probably assume it
 is okay to change it. */
-//var t = opt2.text; 
+//var t = opt2.text;
 //expect_DOM_exception( "text", DOMException.NO_MODIFICATION_ALLOWED_ERR, function(){opt2.text = "avvik";} )
 //test("text",opt2.text,t);
-var i = opt.index; 
+var i = opt.index;
 expect_DOM_exception( "index", DOMException.NO_MODIFICATION_ALLOWED_ERR, function(){opt.index = 3;} )
 test("index",opt.index,i);
- 
-  
 
 
-    
+
+
+
 } catch (e) { exception(e); }
 
 

--- a/core/standards/scripts/jstest-core-2/HTML/scripts/htmlparamelement.js
+++ b/core/standards/scripts/jstest-core-2/HTML/scripts/htmlparamelement.js
@@ -7,8 +7,8 @@ var cvs = "$Id: htmlparamelement.js 4838 2006-01-18 05:59:01Z hallvord $";
 function testParam()
 {
   testmodule( "HTMLParamElement", cvs );
-  
-  try 
+
+  try
   {
     var p1 = self.opener.document.getElementById("myParam");
 	var p2 = self.opener.document.getElementById("myParam2");
@@ -27,10 +27,10 @@ function testParam()
     tdef("type",p.type);
     tdef("value",p.value);
     tdef("name",p.valueType);
- 
+
     p = p1;
 	testcase( "param object property values from default" );
-  
+
     test("name",p.name,"");
     test("type",p.type,"");
     test("value",p.value,"");
@@ -38,7 +38,7 @@ function testParam()
 
     p = p2;
 	testcase( "param object property values from attributes" );
-  
+
     test("name",p.name,"image");
     test("type",p.type,"image/jpeg");
     test("value",p.value,"silmaril.jpg");

--- a/core/standards/scripts/jstest-core-2/HTML/scripts/htmlselectelement.js
+++ b/core/standards/scripts/jstest-core-2/HTML/scripts/htmlselectelement.js
@@ -20,7 +20,7 @@ try {
   testcase( "object" );
 
   test("class",sel,"[object HTMLSelectElement]");
-  
+
   testcase( "attribute object class" );
 
   test("form",sel.form,"[object HTMLFormElement]");
@@ -42,9 +42,9 @@ try {
     tdef("size",sel.size);
     tdef("tabIndex",sel.tabIndex);
   }
- 
+
   testcase( "read property values" );
-  
+
   test("type",sel.type,"select-one");
   test("selectedIndex",sel.selectedIndex,-1);
   test("value",sel.value,"");
@@ -58,11 +58,11 @@ try {
     test("multiple",sel.multiple,false);
     test("size",sel.size,0);
     test("tabIndex",sel.tabIndex,0);
-  }  
+  }
 
   sel = document.getElementById("mySelect2");
   testcase( "properties exists, attributes in use" );
-  
+
   tdef("type",sel.type);
   tdef("selectedIndex",sel.selectedIndex);
   tdef("value",sel.value);
@@ -76,11 +76,11 @@ try {
   tdef("tabIndex",sel.tabIndex);
   if(is_phase(2))
   {
-  }  
- 
+  }
+
 
   testcase( "read property values from attributes" );
-  
+
   test("type",sel.type,"select-one");
   test("selectedIndex",sel.selectedIndex,1);
   test("value",sel.value,"her");
@@ -92,12 +92,12 @@ try {
   test("name",sel.name,"sel");
   test("size",sel.size,3);
   test("tabIndex",sel.tabIndex,2);
-  
+
 
   testcase( "properties are writeable" );
-  
+
   sel.value = "der";
-  
+
   test("value",sel.value,"der");
   test("selectedIndex",sel.selectedIndex,2);
   sel.selectedIndex = 0;
@@ -118,9 +118,9 @@ try {
   test("tabIndex",sel.tabIndex,1);
   sel.name = "sel2";
   test("name",sel.name,"sel2");
-  
 
- 
+
+
   testcase( "properties are not writeable" );
 
   var sel_type = sel.type;
@@ -130,7 +130,7 @@ try {
 //  test("length",sel.length,2);
   expect_DOM_exception( "form", DOMException.NO_MODIFICATION_ALLOWED_ERR, function(){sel.form = form2;});
   test("form",sel.form,form);
-  var options = sel.options; 
+  var options = sel.options;
   expect_DOM_exception( "options", DOMException.NO_MODIFICATION_ALLOWED_ERR, function(){sel.options = null;});
   test("options",sel.options,options);
   expect_DOM_exception( "options", DOMException.NO_MODIFICATION_ALLOWED_ERR, function(){sel.options = "feil";});
@@ -143,8 +143,8 @@ try {
   opt  = document.createElement ("option");
   cnt  = document.createTextNode("text");
   opt.insertBefore(cnt,null);
-  
-  
+
+
   tdef("add",sel.add);
   tdef("remove",sel.remove);
   tdef("blur",sel.blur);
@@ -159,11 +159,11 @@ try {
 
   var l2 = sel2.length;
   var l  = sel.length;
-  
+
   sel2.add(opt,null);
 //  test("add",sel.length,l+1);
   test("add ..",sel2.length,l2+1);
-  
+
   l2 = sel2.length;
   l  = sel.length;
   sel2.remove(0);
@@ -172,7 +172,7 @@ try {
 
   testcase( "regression test for bug# 43154");
   var sel3 = document.getElementById("sel3");
-  test("value", sel3.value, "elephant"); 
+  test("value", sel3.value, "elephant");
 
 } catch (e) { exception(e); }
 

--- a/core/standards/scripts/jstest-core-2/HTML/scripts/htmltablecellelement.js
+++ b/core/standards/scripts/jstest-core-2/HTML/scripts/htmltablecellelement.js
@@ -12,14 +12,14 @@ try {
   var row   = document.getElementById("myRow");
   var cell1 = document.getElementById("myCell");
   var cell2 = document.getElementById("myCell2");
-  
+
   testcase( "object" );
 
   test("class",cell1,"[object HTMLTableCellElement]");
 
   testcase( "properties exists" );
   var cell = cell1;
-  
+
   tdef("cellIndex",cell.cellIndex);
   tdef("align",cell.align);
   tdef("axis",cell.axis);
@@ -35,10 +35,10 @@ try {
   tdef("abbr",cell.abbr);
   tdef("ch",cell.ch);
   tdef("chOff",cell.chOff);
-  
+
   testcase( "read property values" );
   cell = cell1;
-  
+
   test("cellIndex",cell.cellIndex,0);
   test("align",cell.align,"left");
   test("axis",cell.axis,"");
@@ -55,11 +55,11 @@ try {
   var ch = ".";
   if(row.lang == "fr") ch = ",";
   test("ch",row.ch,ch);
-  test("chOff",cell.chOff,""); 
+  test("chOff",cell.chOff,"");
 
   testcase( "properties exists, attributes in use" );
   var cell = cell2;
-  
+
   tdef("cellIndex",cell.cellIndex);
   tdef("align",cell.align);
   tdef("axis",cell.axis);
@@ -78,7 +78,7 @@ try {
 
   testcase( "read property values from attributes" );
   cell = cell2;
- 
+
   test("cellIndex",cell.cellIndex,1);
   test("align",cell.align,"right");
   test("axis",cell.axis,"myCell");
@@ -95,10 +95,10 @@ try {
   test("abbr",cell.abbr,"kort");
   test("ch",cell.ch,"-");
   test("chOff",cell.chOff,"1");
-  
+
   testcase( "properties are writeable" );
   cell = cell2;
-  
+
   cell.align="center";
   test("align",cell.align,"center");
   cell.bgColor="Blue";
@@ -138,7 +138,7 @@ try {
   expect_DOM_exception( "cellIndex", DOMException.NO_MODIFICATION_ALLOWED_ERR, function(){cell.cellIndex = 7;} )
   test("cellIndex",cell.cellIndex,cellIndex);
 	
-    
+
 } catch (e) { exception(e); }
 
 

--- a/core/standards/scripts/jstest-core-2/HTML/scripts/htmltablecolelement.js
+++ b/core/standards/scripts/jstest-core-2/HTML/scripts/htmltablecolelement.js
@@ -11,14 +11,14 @@ try {
   var tab1  = document.getElementById("myTable");
   var col1  = document.getElementById("myCol");
   var col2  = document.getElementById("myCol2");
-  
+
   testcase( "object" );
 
   test("class",col1,"[object HTMLTableColElement]");
-  
+
   testcase( "properties exists" );
   var col = col1;
-  
+
   tdef("align",col.align);
   if(is_phase(2))
   {
@@ -28,10 +28,10 @@ try {
   tdef("span",col.span);
   tdef("vAlign",col.vAlign);
   tdef("width",col.width);
-  
+
   testcase( "read property values" );
   col = col1;
-  
+
   var defalign = "left";
   if(col.dir == "rtl")
     defalign = "right";
@@ -48,11 +48,11 @@ try {
   test("span",col.span,1);
   test("vAlign",col.vAlign,"middle");
   test("width",col.width,"");
-  
+
 
   testcase( "read property values from attributes" );
   col = col2;
-  
+
   test("align",col.align,"right");
   if(is_phase(2))
   {
@@ -66,7 +66,7 @@ try {
   test("regression test for bug #76434 testcase 350", col.attributes.getNamedItem('char').value, "-");
   test("regression test for bug #76434 testcase 352", col.attributes.getNamedItem('charoff').value, "1%");
   test("regression test for bug #76434 testcase 355", col.attributes.getNamedItem('span').value, 2);
-  
+
   testcase( "properties are writeable" );
   col = col2;
 

--- a/core/standards/scripts/jstest-core-2/HTML/scripts/htmltableelement.js
+++ b/core/standards/scripts/jstest-core-2/HTML/scripts/htmltableelement.js
@@ -10,19 +10,19 @@ testmodule( "HTMLTableElement", cvs );
 try {
   var tab1  = document.getElementById("myTable");
   var tab2  = document.getElementById("myTable2");
-  
+
   testcase( "object" );
 
   test("class",tab1,"[object HTMLTableElement]");
-  
+
   testcase( "attribute object class" );
 
   test("rows",tab1.rows,"[object HTMLCollection]");
   test("tBodies",tab1.tBodies,"[object HTMLCollection]");
-  
+
   testcase( "properties exists" );
   var tab = tab1;
-  
+
   tdef("caption",tab.caption);
   tdef("tHead",tab.tHead);
   tdef("tFoot",tab.tFoot);
@@ -38,10 +38,10 @@ try {
   tdef("summary",tab.summary);
   tdef("width",tab.width);
   test("tBodies", tab.tBodies, "[object HTMLCollection]");
-  
+
   testcase( "read property values" );
   tab = tab1;
-  
+
   test("caption",tab.caption,null);
   test("tHead",tab.tHead,null);
   test("tFoot",tab.tFoot,null);
@@ -55,11 +55,11 @@ try {
   test("rules",tab.rules,"");
   test("summary",tab.summary,"");
   test("width",tab.width,"");
-  
+
 
   testcase( "properties exists, attributes in use" );
   var tab = tab2;
-  
+
   tdef("caption",tab.caption);
   tdef("tHead",tab.tHead);
   tdef("tFoot",tab.tFoot);
@@ -77,7 +77,7 @@ try {
 
   testcase( "read property values from attributes" );
   tab = tab2;
-  
+
   if(tab.caption != undefined)
     test("caption",tab.caption.align,"left");
   if(tab.tHead != undefined)
@@ -97,16 +97,16 @@ try {
   test("summary",tab.summary,"summary");
   test("width",tab.width,"100%");
 
-  
+
   testcase( "properties are writeable" );
   tab = tab2;
-  
+
   var newCaption = 	document.createElement ("caption");
   var cap = tab.caption; tab.caption = newCaption;
   test("caption",tab.caption,newCaption);
   tab.caption = cap;
   test("caption",tab.caption,cap);
-  
+
   var newHead = 	document.createElement ("thead");
   var temp = tab.tHead; tab.tHead = newHead;
   test("tHead",tab.tHead,newHead);
@@ -172,7 +172,7 @@ try {
 
 
   testcase( "methods" );
- 
+
   if(tab2.createTHead != undefined)
   {
     var thold = tab2.tHead;
@@ -254,7 +254,7 @@ try {
   }
 
 
-    
+
 } catch (e) { exception(e); }
 
 

--- a/core/standards/scripts/jstest-core-2/HTML/scripts/htmltablerowelement.js
+++ b/core/standards/scripts/jstest-core-2/HTML/scripts/htmltablerowelement.js
@@ -11,7 +11,7 @@ try {
   var tab1  = document.getElementById("myTable");
   var row1  = document.getElementById("myRow");
   var row2  = document.getElementById("myRow2");
-  
+
   testcase( "object" );
 
   test("class",row1,"[object HTMLTableRowElement]");
@@ -19,10 +19,10 @@ try {
   testcase( "attribute object class" );
 
   test("cells",row1.cells,"[object HTMLCollection]");
-  
+
   testcase( "properties exists" );
   var row = row1;
-  
+
   tdef("rowIndex",row.rowIndex);
   tdef("sectionRowIndex",row.sectionRowIndex);
   tdef("cells",row.cells);
@@ -37,10 +37,10 @@ try {
   }
 
   tdef("vAlign",row.vAlign);
-  
+
   testcase( "read property values" );
   row = row1;
-  
+
   var defalign = "left";
   if(row.dir == "rtl")
     defalign = "right";
@@ -62,11 +62,11 @@ try {
   }
 
   test("vAlign",row.vAlign,"middle");
-  
+
 
   testcase( "properties exists, attributes in use" );
   var row = row2;
-  
+
   tdef("rowIndex",row.rowIndex);
   tdef("sectionRowIndex",row.sectionRowIndex);
   tdef("cells",row.cells);
@@ -81,7 +81,7 @@ try {
 
   testcase( "read property values from attributes" );
   row = row2;
-  
+
   test("rowIndex",row.rowIndex,3);
   test("sectionRowIndex",row.sectionRowIndex,1);
   test("cells",row.cells.length,1);
@@ -96,7 +96,7 @@ try {
 
   testcase( "properties are writeable" );
   row = row2;
-  
+
   row.align="center";
   test("align",row.align,"center");
   row.bgColor="blue";
@@ -112,7 +112,7 @@ try {
   }
   row.vAlign="bottom";
   test("vAlign",row.vAlign,"bottom");
- 
+
   testcase( "properties are not writeable" );
 
   var rowIndex = row.rowIndex;
@@ -132,7 +132,7 @@ try {
 
 
   testcase( "methods" );
-  
+
   if(row2.insertCell != undefined)
   {
     var cnew = row2.insertCell(0);
@@ -162,7 +162,7 @@ try {
   }
 
   testcase( "default attribute values" );
-  
+
   var td = document.getElementsByTagName('TD').item(0);
   tdef("TD colspan #1", td);
 

--- a/core/standards/scripts/jstest-core-2/HTML/scripts/htmltablesectionelement.js
+++ b/core/standards/scripts/jstest-core-2/HTML/scripts/htmltablesectionelement.js
@@ -12,7 +12,7 @@ try {
   var tab2  = document.getElementById("myTableSection2");
   var tab3  = document.getElementById("myTableSection3");
   var row   = document.getElementById("myRow");
-  
+
   testcase( "object" );
 
   test("class thead",tab1,"[object HTMLTableSectionElement]");
@@ -21,8 +21,8 @@ try {
 
   testcase( "attribute object class" );
 
-  test("rows",tab1.rows,"[object HTMLCollection]"); 
-  
+  test("rows",tab1.rows,"[object HTMLCollection]");
+
   testcase( "properties exists" );
   var tab = tab1;
  /*
@@ -33,26 +33,26 @@ try {
 
   testcase( "read default property values" );
   tab = tab1;
-  
+
   test("align",tab.align,"left");
   test("vAlign",tab.vAlign,"middle");
   if(tab.rows != undefined)
   {
     test("rows",tab.rows.length,0);
   }
- 
-  
+
+
 
   testcase( "properties exists, attributes in use" );
   var tab = tab2;
-  
+
   tdef("align",tab.align);
   tdef("vAlign",tab.vAlign);
   tdef("rows",tab.rows);
 
   testcase( "read property values from attributes" );
   tab = tab2;
-  
+
   test("align",tab.align,"right");
   test("vAlign",tab.vAlign,"top");
   if(tab.rows != undefined)
@@ -62,7 +62,7 @@ try {
   }
   testcase( "properties are writeable" );
   tab = tab2;
-  
+
   tab.align="center";
   test("align",tab.align,"center");
   tab.vAlign="top";
@@ -74,7 +74,7 @@ try {
   var rows = tab.rows;
   expect_DOM_exception( "rows", DOMException.NO_MODIFICATION_ALLOWED_ERR, function(){tab.rows = null;} )
   test("rows",tab.rows,rows);
- 
+
 	
   testcase( "methods exist" );
 
@@ -119,7 +119,7 @@ try {
   }
 
 
-    
+
 } catch (e) { exception(e); }
 
 

--- a/core/standards/scripts/jstest-core-2/HTML/scripts/htmltextareaelement.js
+++ b/core/standards/scripts/jstest-core-2/HTML/scripts/htmltextareaelement.js
@@ -12,18 +12,18 @@ try {
   var form2 = document.getElementById("myForm2");
   var inp1  = document.getElementById("myTextArea");
   var inp2  = document.getElementById("myTextArea2");
-  
+
   testcase( "object" );
 
   test("class",inp1,"[object HTMLTextAreaElement]");
-  
+
   testcase( "attribute object class" );
 
   test("form",inp1.form,"[object HTMLFormElement]");
-    
+
   testcase( "properties exists" );
   var inp = inp1;
-  
+
   tdef("defaultValue",inp.defaultValue);
   tdef("form",inp.form);
   tdef("accessKey",inp.accessKey);
@@ -35,10 +35,10 @@ try {
   tdef("tabIndex",inp.tabIndex);
   tdef("type",inp.type);
   tdef("value",inp.value);
-  
+
   testcase( "read property values" );
   inp = inp1;
-  
+
   test("defaultValue",inp.defaultValue,"");
   test("form",inp.form,form);
   test("accessKey",inp.accessKey,"");
@@ -52,11 +52,11 @@ try {
   test("tabIndex",inp.tabIndex,0);
   test("type",inp.type,"textarea");
   test("value",inp.value,"");
-  
+
 
   testcase( "properties exists, attributes in use" );
   var inp = inp2;
-  
+
   tdef("defaultValue",inp.defaultValue);
   tdef("form",inp.form);
   tdef("accessKey",inp.accessKey);
@@ -71,7 +71,7 @@ try {
 
   testcase( "read property values from attributes" );
   inp = inp2;
-  
+
   test("defaultValue",inp.defaultValue,"verdi");
   test("form",inp.form,form);
   test("accessKey",inp.accessKey,"U");
@@ -86,7 +86,7 @@ try {
 
   testcase( "properties are writeable" );
   inp = inp2;
-  
+
   inp.defaultValue = "endring";
   test("defaultValue",inp.defaultValue,"endring");
   inp.accessKey = "R";
@@ -113,7 +113,7 @@ try {
   test("form",inp.form,form);
   var t = inp.type; expect_DOM_exception( "type", DOMException.NO_MODIFICATION_ALLOWED_ERR, function(){inp.type = "illegal";} )
   test("type",inp.type,t);
-    
+
 	
   testcase( "methods exist" );
 
@@ -123,7 +123,7 @@ try {
 
 
   testcase( "methods" );
-  
+
   inp.focus();
   test("focus",test_call(),"call_on");
   inp.blur();
@@ -132,7 +132,7 @@ try {
   forget_call();
   inp2.select();
   test("select",test_call(),"call_on");
-    
+
 } catch (e) { exception(e); }
 
 

--- a/core/standards/scripts/jstest-core-2/es-regression/scripts/exceptions.js
+++ b/core/standards/scripts/jstest-core-2/es-regression/scripts/exceptions.js
@@ -17,7 +17,7 @@ testcase("Basic catch/throw");
  try {
    zappa=2;
    throw 'Cookies!';
- } 
+ }
  catch (e) {}
  finally {
    zappa=1;
@@ -89,15 +89,15 @@ testcase("Basic catch/throw");
  var tmp = 'failure';
  zappa=10
  try {
-   function f() 
+   function f()
    {
-     try { 
-       if (!--zappa) 
-         throw 'zapata'; 
+     try {
+       if (!--zappa)
+         throw 'zapata';
        else
          f();
-     } 
-     finally { ++zappa; } 
+     }
+     finally { ++zappa; }
    }
    f();
  }
@@ -146,7 +146,7 @@ function return_from_finally()
     return false;
 }
 
-test( "Return from within finally", return_from_finally(), "RIGHT", 167420 );  
+test( "Return from within finally", return_from_finally(), "RIGHT", 167420 );
 
 //////////////////////////////
 //////////////////////////////
@@ -158,7 +158,7 @@ var x = 1;
 // ReferenceError (§8.7.1, §8.7.2)
 
 expect_exception( "ReferenceError #1 (bogus rvalue)", ReferenceError, function(){show(unlikelyvariablename);} );
-  
+
 // Does new of a non-object throw a TypeError (§11.2.2)
 
 expect_exception( "TypeError #1", TypeError, function(){ new x(); } );
@@ -207,12 +207,12 @@ expect_exception( "TypeError #10", TypeError, function(){ show( String( o ) ); }
 // Function.toString on something that isn't a function should
 // throw a type error §15.3.4.2
 
-expect_exception( "TypeError #12", TypeError, 
+expect_exception( "TypeError #12", TypeError,
 		  function()
                   {
-                    var x=new Object(); 
-		    x.toString = Function.prototype.toString; 
-		    x.toString(); 
+                    var x=new Object();
+		    x.toString = Function.prototype.toString;
+		    x.toString();
                   } );
 
 // Function::apply should barf if _this_ is not a function; that
@@ -315,10 +315,10 @@ var third_this = null;
 function A() { this.a = a; }
 function B() { this.b = b; }
 
-function a() 
-{ 
+function a()
+{
   second_this = this;
-  throw new Error(); 
+  throw new Error();
 }
 
 function b(x)
@@ -367,7 +367,7 @@ scopetest();
 // Bug 227582: compiler would crash when compiling this function.
 // A WITH pushed by a catch would be conflated with a WITH pushed
 // by the program, leading to incorrect behavior in the latter case.
-// The bug only appears if there's a TRY..FINALLY without a CATCH, 
+// The bug only appears if there's a TRY..FINALLY without a CATCH,
 // with a surrounding WITH.
 
 var frotz = 42;
@@ -382,7 +382,7 @@ function test227582() {
 	}
     }
 }
-test( "exception handling inside with", test227582() + frotz, "done37", 
+test( "exception handling inside with", test227582() + frotz, "done37",
       "#227582" );
 
 testmodule_finished();

--- a/core/standards/scripts/jstest-core-2/es-regression/scripts/function.js
+++ b/core/standards/scripts/jstest-core-2/es-regression/scripts/function.js
@@ -1,6 +1,6 @@
 /* -*- mode: C++; tab-width: 4 -*-
  *
- * Functionality and regression tests -- Function objects 
+ * Functionality and regression tests -- Function objects
  *
  * Copyright (C) 2002 Opera Software AS.  All rights reserved.
  *
@@ -20,19 +20,19 @@ x = Function('x','y','return x+y;'),
 	testinstance( "Function('x','y','return x+y;')", x, Function );
 test( "#1 x(1,2)", x(1,2), 3 );
 test( "#1 x.length", x.length, 2 );
- 
+
 x = Function('x,y','return x+y;'),
 	testinstance( "Function('x,y','return x+y;')", x, Function );
 test( "#2 x(1,2)", x(1,2), 3 );
 test( "#2 x.length", x.length, 2 );
- 
+
 x = new Function('x','y','return x+y;'),
 	testinstance( "new Function('x','y','return x+y;')", x, Function );
 test( "#3 x(1,2)", x(1,2), 3 );
 test( "#3 x.length", x.length, 2 );
- 
+
 var testvar = 37;
-function f_returning_Function() 
+function f_returning_Function()
 {
 	var testvar = 42;
 	return new Function( 'return testvar;' );
@@ -140,11 +140,11 @@ testcase( "Decompiler" );
 if (! (isBytecoded() || decompilerRemoved()) )
 {
 test_spaceagnostic( 'fn.toString #1', (function (x) { return 1; }).toString(), "function (x) { return 1; }" );
-test_spaceagnostic( 'fn.toString #2', 
-					(function (x,y) { function foo() { return 2; } return 1; }).toString(), 
-					"function (x,y) { function foo() { return 2; } return 1; }", 
+test_spaceagnostic( 'fn.toString #2',
+					(function (x,y) { function foo() { return 2; } return 1; }).toString(),
+					"function (x,y) { function foo() { return 2; } return 1; }",
 					82063 );
-test_spaceagnostic( 'fn.toString #3', (function () { try {} catch (e) { j=e; } }).toString(), 
+test_spaceagnostic( 'fn.toString #3', (function () { try {} catch (e) { j=e; } }).toString(),
 					"function () { try {} catch (e) { j = e; } }",
 					"#128890" );
 // The following test the parenthesizing logic -- parentheses should be inserted when
@@ -291,12 +291,12 @@ test( "function.arguments content live on #7", x[1].valueOf(), "hei" )
 // Bug in an early implementation, seen on excite.com: only the first call
 // to makeArray had access to makeArray.arguments, the second would fail.
 
-function makeArray() 
+function makeArray()
 {
   this[0] = makeArray.arguments.length;
-  for (i = 0; i<makeArray.arguments.length; i++) 
+  for (i = 0; i<makeArray.arguments.length; i++)
   {
-    this[i+1] = makeArray.arguments[i]; 
+    this[i+1] = makeArray.arguments[i];
   }
 }
 try {
@@ -305,7 +305,7 @@ try {
 }
 catch(e) { exception(e); }
 
-// Bug seen on www.apple.com/switch: with a local variable and more 
+// Bug seen on www.apple.com/switch: with a local variable and more
 // actuals than formals, and both the arguments and activation
 // optimizations in effect, some of the elements of the arguments
 // array were set to undefined.
@@ -335,7 +335,7 @@ test( "#122536: parameters in optimized constructed function", f("hei"), "hei" )
 // property and *then* used for variable instantiation, which I take
 // to mean even instantiating the formals).
 //
-// Test moved to bugs section because it caused an unhandleable stack 
+// Test moved to bugs section because it caused an unhandleable stack
 // overflow.
 
 // Bug #79933: a crash bug, and improper handling of the arguments property
@@ -351,7 +351,7 @@ var expected = [99,1,2,3,3,2,1,99,null];
 var expno = 0;
 
 var x = 0;
-function mf(a,b) 
+function mf(a,b)
 {
   shouldBe("mf.arguments[0]",expected[expno++]);
   x++;
@@ -378,7 +378,7 @@ function argarray_reverse(a,b,c,d)
 }
 argarray_reverse(4,3,2,1);
 
-// Bug #186815: a local declaration of 'arguments' without an initializer 
+// Bug #186815: a local declaration of 'arguments' without an initializer
 // should not override the existing value.
 
 function arguments_declared()
@@ -412,8 +412,8 @@ function hideallmenus_156720() {
 }
 
 var exn = false;
-try { 
-	hideallmenus_156720(10); 
+try {
+	hideallmenus_156720(10);
 }
 catch (e)
 {
@@ -457,7 +457,7 @@ function test_enumerable_arguments_property()
 }
 test( "function.arguments is not enumerable", test_enumerable_arguments_property(), true, 21957 );
 
-/* RTS bug (#213623): scope objects in reified scopes should not 
+/* RTS bug (#213623): scope objects in reified scopes should not
    have prototypes */
 function test_prototypes_in_reified_scopes()
 {

--- a/core/standards/scripts/jstest-core-2/es-regression/scripts/mathmeths.js
+++ b/core/standards/scripts/jstest-core-2/es-regression/scripts/mathmeths.js
@@ -2,7 +2,7 @@
  * 2001-10-22 hrms
  * 2002-04-03 lth
  *
- * Comments: 
+ * Comments:
  * This script first tests the following Math methods:
  *
  *    Math.abs,  Math.acos,   Math.asin,   Math.atan,   Math.ceil,
@@ -53,336 +53,336 @@ try {
 testcase( "Math methods with esoteric input" );
 
 
-test( "Math.abs ( Math.E ) ", Math.abs ( Math.E ) , 2.718281828459045 ); 
+test( "Math.abs ( Math.E ) ", Math.abs ( Math.E ) , 2.718281828459045 );
 
-test( "Math.abs ( Math.LN2 ) ", Math.abs ( Math.LN2 ) , 0.6931471805599453 ); 
+test( "Math.abs ( Math.LN2 ) ", Math.abs ( Math.LN2 ) , 0.6931471805599453 );
 
 
-test( "Math.abs ( Math.LN10 ) ", Math.abs ( Math.LN10 ) , 2.302585092994046 ); 
+test( "Math.abs ( Math.LN10 ) ", Math.abs ( Math.LN10 ) , 2.302585092994046 );
 
 
-test( "Math.abs ( Math.LOG2E ) ", Math.abs ( Math.LOG2E ) , 1.4426950408889633 ); 
+test( "Math.abs ( Math.LOG2E ) ", Math.abs ( Math.LOG2E ) , 1.4426950408889633 );
 
 
-test( "Math.abs ( Math.LOG10E ) ", Math.abs ( Math.LOG10E ) , 0.4342944819032518 ); 
+test( "Math.abs ( Math.LOG10E ) ", Math.abs ( Math.LOG10E ) , 0.4342944819032518 );
 
 
-test( "Math.abs ( Math.PI ) ", Math.abs ( Math.PI ) , 3.141592653589793 ); 
+test( "Math.abs ( Math.PI ) ", Math.abs ( Math.PI ) , 3.141592653589793 );
 
 
-test( "Math.abs ( Math.SQRT1_2 ) ", Math.abs ( Math.SQRT1_2 ) , 0.7071067811865476 ); 
+test( "Math.abs ( Math.SQRT1_2 ) ", Math.abs ( Math.SQRT1_2 ) , 0.7071067811865476 );
 
 
-test( "Math.abs ( Math.SQRT2 ) ", Math.abs ( Math.SQRT2 ) , 1.4142135623730951 ); 
+test( "Math.abs ( Math.SQRT2 ) ", Math.abs ( Math.SQRT2 ) , 1.4142135623730951 );
 
 
-test( "Math.abs ( Number.POSITIVE_INFINITY ) ", Math.abs ( Number.POSITIVE_INFINITY ) , Infinity ); 
+test( "Math.abs ( Number.POSITIVE_INFINITY ) ", Math.abs ( Number.POSITIVE_INFINITY ) , Infinity );
 
 
-test( "Math.abs ( Number.NEGATIVE_INFINITY ) ", Math.abs ( Number.NEGATIVE_INFINITY ) , Infinity ); 
+test( "Math.abs ( Number.NEGATIVE_INFINITY ) ", Math.abs ( Number.NEGATIVE_INFINITY ) , Infinity );
 
 
-test( "Math.abs ( Number.MAX_VALUE ) ", Math.abs ( Number.MAX_VALUE ) , 1.7976931348623157e+308 ); 
+test( "Math.abs ( Number.MAX_VALUE ) ", Math.abs ( Number.MAX_VALUE ) , 1.7976931348623157e+308 );
 
 
-test( "Math.abs ( Number.MIN_VALUE ) ", Math.abs ( Number.MIN_VALUE ) , Number.MIN_VALUE ); 
+test( "Math.abs ( Number.MIN_VALUE ) ", Math.abs ( Number.MIN_VALUE ) , Number.MIN_VALUE );
 
 
-test( "Math.abs ( Number.NaN ) ", Math.abs ( Number.NaN ) , Number.NaN ); 
+test( "Math.abs ( Number.NaN ) ", Math.abs ( Number.NaN ) , Number.NaN );
 
 
-test( "Math.abs ( 0 ) ", Math.abs ( 0 ) , 0 ); 
+test( "Math.abs ( 0 ) ", Math.abs ( 0 ) , 0 );
 
 
-test( "Math.abs ( -0 ) ", Math.abs ( -0 ) , 0 ); 
+test( "Math.abs ( -0 ) ", Math.abs ( -0 ) , 0 );
 
-test( "Math.abs ( 1.012 ) ", Math.abs ( 1.012 ) , 1.012 ); 
+test( "Math.abs ( 1.012 ) ", Math.abs ( 1.012 ) , 1.012 );
 
 
-test( "Math.abs ( -1.12 ) ", Math.abs ( -1.12 ) , 1.12 ); 
+test( "Math.abs ( -1.12 ) ", Math.abs ( -1.12 ) , 1.12 );
 
 
-test( "Math.abs ( 1 ) ", Math.abs ( 1 ) , 1 ); 
+test( "Math.abs ( 1 ) ", Math.abs ( 1 ) , 1 );
 
 
-test( "Math.abs ( -0.5 ) ", Math.abs ( -0.5 ) , 0.5 ); 
+test( "Math.abs ( -0.5 ) ", Math.abs ( -0.5 ) , 0.5 );
 
 
-test( "Math.abs ( 0.499 ) ", Math.abs ( 0.499 ) , 0.499 ); 
+test( "Math.abs ( 0.499 ) ", Math.abs ( 0.499 ) , 0.499 );
 
 
-test( "Math.acos ( Math.E ) ", Math.acos ( Math.E ) , Number.NaN ); 
+test( "Math.acos ( Math.E ) ", Math.acos ( Math.E ) , Number.NaN );
 
 
-teste( "Math.acos ( Math.LN2 ) ", Math.acos ( Math.LN2 ) , 0.8049501319758164 ); 
+teste( "Math.acos ( Math.LN2 ) ", Math.acos ( Math.LN2 ) , 0.8049501319758164 );
 
 
-test( "Math.acos ( Math.LN10 ) ", Math.acos ( Math.LN10 ) , Number.NaN ); 
+test( "Math.acos ( Math.LN10 ) ", Math.acos ( Math.LN10 ) , Number.NaN );
 
 
-test( "Math.acos ( Math.LOG2E ) ", Math.acos ( Math.LOG2E ) , Number.NaN ); 
+test( "Math.acos ( Math.LOG2E ) ", Math.acos ( Math.LOG2E ) , Number.NaN );
 
 
-teste( "Math.acos ( Math.LOG10E ) ", Math.acos ( Math.LOG10E ) , 1.121541436112827 ); 
+teste( "Math.acos ( Math.LOG10E ) ", Math.acos ( Math.LOG10E ) , 1.121541436112827 );
 
 
-test( "Math.acos ( Math.PI ) ", Math.acos ( Math.PI ) , Number.NaN ); 
+test( "Math.acos ( Math.PI ) ", Math.acos ( Math.PI ) , Number.NaN );
 
 
-teste( "Math.acos ( Math.SQRT1_2 ) ", Math.acos ( Math.SQRT1_2 ) , 0.7853981633974483 ); 
+teste( "Math.acos ( Math.SQRT1_2 ) ", Math.acos ( Math.SQRT1_2 ) , 0.7853981633974483 );
 
 
-test( "Math.acos ( Math.SQRT2 ) ", Math.acos ( Math.SQRT2 ) , Number.NaN ); 
+test( "Math.acos ( Math.SQRT2 ) ", Math.acos ( Math.SQRT2 ) , Number.NaN );
 
 
-test( "Math.acos ( Number.POSITIVE_INFINITY ) ", Math.acos ( Number.POSITIVE_INFINITY ) , Number.NaN ); 
+test( "Math.acos ( Number.POSITIVE_INFINITY ) ", Math.acos ( Number.POSITIVE_INFINITY ) , Number.NaN );
 
 
-test( "Math.acos ( Number.NEGATIVE_INFINITY ) ", Math.acos ( Number.NEGATIVE_INFINITY ) , Number.NaN ); 
+test( "Math.acos ( Number.NEGATIVE_INFINITY ) ", Math.acos ( Number.NEGATIVE_INFINITY ) , Number.NaN );
 
 
-test( "Math.acos ( Number.MAX_VALUE ) ", Math.acos ( Number.MAX_VALUE ) , Number.NaN ); 
+test( "Math.acos ( Number.MAX_VALUE ) ", Math.acos ( Number.MAX_VALUE ) , Number.NaN );
 
 
-teste( "Math.acos ( Number.MIN_VALUE ) ", Math.acos ( Number.MIN_VALUE ) , 1.5707963267948965 ); 
+teste( "Math.acos ( Number.MIN_VALUE ) ", Math.acos ( Number.MIN_VALUE ) , 1.5707963267948965 );
 
 
-test( "Math.acos ( Number.NaN ) ", Math.acos ( Number.NaN ) , Number.NaN ); 
+test( "Math.acos ( Number.NaN ) ", Math.acos ( Number.NaN ) , Number.NaN );
 
 
-teste( "Math.acos ( 0 ) ", Math.acos ( 0 ) , 1.5707963267948965 ); 
+teste( "Math.acos ( 0 ) ", Math.acos ( 0 ) , 1.5707963267948965 );
 
 
-teste( "Math.acos ( -0 ) ", Math.acos ( -0 ) , 1.5707963267948965 ); 
+teste( "Math.acos ( -0 ) ", Math.acos ( -0 ) , 1.5707963267948965 );
 
 
-test( "Math.acos ( 1.012 ) ", Math.acos ( 1.012 ) , Number.NaN ); 
+test( "Math.acos ( 1.012 ) ", Math.acos ( 1.012 ) , Number.NaN );
 
 
-test( "Math.acos ( -1.12 ) ", Math.acos ( -1.12 ) , Number.NaN ); 
+test( "Math.acos ( -1.12 ) ", Math.acos ( -1.12 ) , Number.NaN );
 
 
-test( "Math.acos ( 1 ) ", Math.acos ( 1 ) , 0 ); 
+test( "Math.acos ( 1 ) ", Math.acos ( 1 ) , 0 );
 
 
-teste( "Math.acos ( -0.5 ) ", Math.acos ( -0.5 ) , 2.0943951023931957 ); 
+teste( "Math.acos ( -0.5 ) ", Math.acos ( -0.5 ) , 2.0943951023931957 );
 
 
-teste( "Math.acos ( 0.499 ) ", Math.acos ( 0.499 ) , 1.0483518673474 ); 
+teste( "Math.acos ( 0.499 ) ", Math.acos ( 0.499 ) , 1.0483518673474 );
 
 
-test( "Math.asin ( Math.E ) ", Math.asin ( Math.E ) , Number.NaN ); 
+test( "Math.asin ( Math.E ) ", Math.asin ( Math.E ) , Number.NaN );
 
 
-teste( "Math.asin ( Math.LN2 ) ", Math.asin ( Math.LN2 ) , 0.7658461948190802 ); 
+teste( "Math.asin ( Math.LN2 ) ", Math.asin ( Math.LN2 ) , 0.7658461948190802 );
 
 
-test( "Math.asin ( Math.LN10 ) ", Math.asin ( Math.LN10 ) , Number.NaN ); 
+test( "Math.asin ( Math.LN10 ) ", Math.asin ( Math.LN10 ) , Number.NaN );
 
 
-test( "Math.asin ( Math.LOG2E ) ", Math.asin ( Math.LOG2E ) , Number.NaN ); 
+test( "Math.asin ( Math.LOG2E ) ", Math.asin ( Math.LOG2E ) , Number.NaN );
 
 
-teste( "Math.asin ( Math.LOG10E ) ", Math.asin ( Math.LOG10E ) , 0.44925489068206964 ); 
+teste( "Math.asin ( Math.LOG10E ) ", Math.asin ( Math.LOG10E ) , 0.44925489068206964 );
 
 
-test( "Math.asin ( Math.PI ) ", Math.asin ( Math.PI ) , Number.NaN ); 
+test( "Math.asin ( Math.PI ) ", Math.asin ( Math.PI ) , Number.NaN );
 
 
-teste( "Math.asin ( Math.SQRT1_2 ) ", Math.asin ( Math.SQRT1_2 ) , 0.7853981633974484 ); 
+teste( "Math.asin ( Math.SQRT1_2 ) ", Math.asin ( Math.SQRT1_2 ) , 0.7853981633974484 );
 
 
-test( "Math.asin ( Math.SQRT2 ) ", Math.asin ( Math.SQRT2 ) , Number.NaN ); 
+test( "Math.asin ( Math.SQRT2 ) ", Math.asin ( Math.SQRT2 ) , Number.NaN );
 
 
-test( "Math.asin ( Number.POSITIVE_INFINITY ) ", Math.asin ( Number.POSITIVE_INFINITY ) , Number.NaN ); 
+test( "Math.asin ( Number.POSITIVE_INFINITY ) ", Math.asin ( Number.POSITIVE_INFINITY ) , Number.NaN );
 
 
-test( "Math.asin ( Number.NEGATIVE_INFINITY ) ", Math.asin ( Number.NEGATIVE_INFINITY ) , Number.NaN ); 
+test( "Math.asin ( Number.NEGATIVE_INFINITY ) ", Math.asin ( Number.NEGATIVE_INFINITY ) , Number.NaN );
 
 
-test( "Math.asin ( Number.MAX_VALUE ) ", Math.asin ( Number.MAX_VALUE ) , Number.NaN ); 
+test( "Math.asin ( Number.MAX_VALUE ) ", Math.asin ( Number.MAX_VALUE ) , Number.NaN );
 
 
-teste( "Math.asin ( Number.MIN_VALUE ) ", Math.asin ( Number.MIN_VALUE ) , Number.MIN_VALUE ); 
+teste( "Math.asin ( Number.MIN_VALUE ) ", Math.asin ( Number.MIN_VALUE ) , Number.MIN_VALUE );
 
 
-test( "Math.asin ( Number.NaN ) ", Math.asin ( Number.NaN ) , Number.NaN ); 
+test( "Math.asin ( Number.NaN ) ", Math.asin ( Number.NaN ) , Number.NaN );
 
 
-test( "Math.asin ( 0 ) ", Math.asin ( 0 ) , 0 ); 
+test( "Math.asin ( 0 ) ", Math.asin ( 0 ) , 0 );
 
 
-test( "Math.asin ( -0 ) ", Math.asin ( -0 ) , 0 ); 
+test( "Math.asin ( -0 ) ", Math.asin ( -0 ) , 0 );
 
 
-test( "Math.asin ( 1.012 ) ", Math.asin ( 1.012 ) , Number.NaN ); 
+test( "Math.asin ( 1.012 ) ", Math.asin ( 1.012 ) , Number.NaN );
 
 
-test( "Math.asin ( -1.12 ) ", Math.asin ( -1.12 ) , Number.NaN ); 
+test( "Math.asin ( -1.12 ) ", Math.asin ( -1.12 ) , Number.NaN );
 
 
-teste( "Math.asin ( 1 ) ", Math.asin ( 1 ) , 1.5707963267948965 ); 
+teste( "Math.asin ( 1 ) ", Math.asin ( 1 ) , 1.5707963267948965 );
 
 
-teste( "Math.asin ( -0.5 ) ", Math.asin ( -0.5 ) , -0.5235987755982989 ); 
+teste( "Math.asin ( -0.5 ) ", Math.asin ( -0.5 ) , -0.5235987755982989 );
 
 
-teste( "Math.asin ( 0.499 ) ", Math.asin ( 0.499 ) , 0.5224444594474966 ); 
+teste( "Math.asin ( 0.499 ) ", Math.asin ( 0.499 ) , 0.5224444594474966 );
 
 
-teste( "Math.atan ( Math.E ) ", Math.atan ( Math.E ) , 1.2182829050172776 ); 
+teste( "Math.atan ( Math.E ) ", Math.atan ( Math.E ) , 1.2182829050172776 );
 
 
-teste( "Math.atan ( Math.LN2 ) ", Math.atan ( Math.LN2 ) , 0.606111934732855 ); 
+teste( "Math.atan ( Math.LN2 ) ", Math.atan ( Math.LN2 ) , 0.606111934732855 );
 
 
-teste( "Math.atan ( Math.LN10 ) ", Math.atan ( Math.LN10 ) , 1.1610795826858162 ); 
+teste( "Math.atan ( Math.LN10 ) ", Math.atan ( Math.LN10 ) , 1.1610795826858162 );
 
 
-teste( "Math.atan ( Math.LOG2E ) ", Math.atan ( Math.LOG2E ) , 0.9646843920620416 ); 
+teste( "Math.atan ( Math.LOG2E ) ", Math.atan ( Math.LOG2E ) , 0.9646843920620416 );
 
 
-teste( "Math.atan ( Math.LOG10E ) ", Math.atan ( Math.LOG10E ) , 0.4097167441090804 ); 
+teste( "Math.atan ( Math.LOG10E ) ", Math.atan ( Math.LOG10E ) , 0.4097167441090804 );
 
 
-teste( "Math.atan ( Math.PI ) ", Math.atan ( Math.PI ) , 1.2626272556789117 ); 
+teste( "Math.atan ( Math.PI ) ", Math.atan ( Math.PI ) , 1.2626272556789117 );
 
 
-teste( "Math.atan ( Math.SQRT1_2 ) ", Math.atan ( Math.SQRT1_2 ) , 0.6154797086703874 ); 
+teste( "Math.atan ( Math.SQRT1_2 ) ", Math.atan ( Math.SQRT1_2 ) , 0.6154797086703874 );
 
 
-teste( "Math.atan ( Math.SQRT2 ) ", Math.atan ( Math.SQRT2 ) , 0.9553166181245093 ); 
+teste( "Math.atan ( Math.SQRT2 ) ", Math.atan ( Math.SQRT2 ) , 0.9553166181245093 );
 
 
-teste( "Math.atan ( Number.POSITIVE_INFINITY ) ", Math.atan ( Number.POSITIVE_INFINITY ) , 1.5707963267948965 ); 
+teste( "Math.atan ( Number.POSITIVE_INFINITY ) ", Math.atan ( Number.POSITIVE_INFINITY ) , 1.5707963267948965 );
 
 
-teste( "Math.atan ( Number.NEGATIVE_INFINITY ) ", Math.atan ( Number.NEGATIVE_INFINITY ) , -1.5707963267948965 ); 
+teste( "Math.atan ( Number.NEGATIVE_INFINITY ) ", Math.atan ( Number.NEGATIVE_INFINITY ) , -1.5707963267948965 );
 
 
-teste( "Math.atan ( Number.MAX_VALUE ) ", Math.atan ( Number.MAX_VALUE ) , 1.5707963267948965 ); 
+teste( "Math.atan ( Number.MAX_VALUE ) ", Math.atan ( Number.MAX_VALUE ) , 1.5707963267948965 );
 
 
-//test_expect_failure( "Math.atan ( Number.MIN_VALUE ) ", 79971, Math.atan ( Number.MIN_VALUE ) , Number.MIN_VALUE ); 
-teste( "Math.atan ( Number.MIN_VALUE ) ", Math.atan ( Number.MIN_VALUE ) , Number.MIN_VALUE ); 
+//test_expect_failure( "Math.atan ( Number.MIN_VALUE ) ", 79971, Math.atan ( Number.MIN_VALUE ) , Number.MIN_VALUE );
+teste( "Math.atan ( Number.MIN_VALUE ) ", Math.atan ( Number.MIN_VALUE ) , Number.MIN_VALUE );
 
 
-test( "Math.atan ( Number.NaN ) ", Math.atan ( Number.NaN ) , Number.NaN ); 
+test( "Math.atan ( Number.NaN ) ", Math.atan ( Number.NaN ) , Number.NaN );
 
 
-teste( "Math.atan ( 0 ) ", Math.atan ( 0 ) , 0 ); 
+teste( "Math.atan ( 0 ) ", Math.atan ( 0 ) , 0 );
 
 
-teste( "Math.atan ( -0 ) ", Math.atan ( -0 ) , 0 ); 
+teste( "Math.atan ( -0 ) ", Math.atan ( -0 ) , 0 );
 
 
-teste( "Math.atan ( 1.012 ) ", Math.atan ( 1.012 ) , 0.7913623073912894 ); 
+teste( "Math.atan ( 1.012 ) ", Math.atan ( 1.012 ) , 0.7913623073912894 );
 
 
-teste( "Math.atan ( -1.12 ) ", Math.atan ( -1.12 ) , -0.8419416003422657 ); 
+teste( "Math.atan ( -1.12 ) ", Math.atan ( -1.12 ) , -0.8419416003422657 );
 
 
-teste( "Math.atan ( 1 ) ", Math.atan ( 1 ) , 0.7853981633974483 ); 
+teste( "Math.atan ( 1 ) ", Math.atan ( 1 ) , 0.7853981633974483 );
 
 
-teste( "Math.atan ( -0.5 ) ", Math.atan ( -0.5 ) , -0.4636476090008061 ); 
+teste( "Math.atan ( -0.5 ) ", Math.atan ( -0.5 ) , -0.4636476090008061 );
 
 
-teste( "Math.atan ( 0.499 ) ", Math.atan ( 0.499 ) , 0.4628472890436265 ); 
+teste( "Math.atan ( 0.499 ) ", Math.atan ( 0.499 ) , 0.4628472890436265 );
 
 
-test( "Math.ceil ( Math.E ) ", Math.ceil ( Math.E ) , 3 ); 
+test( "Math.ceil ( Math.E ) ", Math.ceil ( Math.E ) , 3 );
 
 
-test( "Math.ceil ( Math.LN2 ) ", Math.ceil ( Math.LN2 ) , 1 ); 
+test( "Math.ceil ( Math.LN2 ) ", Math.ceil ( Math.LN2 ) , 1 );
 
 
-test( "Math.ceil ( Math.LN10 ) ", Math.ceil ( Math.LN10 ) , 3 ); 
+test( "Math.ceil ( Math.LN10 ) ", Math.ceil ( Math.LN10 ) , 3 );
 
 
-test( "Math.ceil ( Math.LOG2E ) ", Math.ceil ( Math.LOG2E ) , 2 ); 
+test( "Math.ceil ( Math.LOG2E ) ", Math.ceil ( Math.LOG2E ) , 2 );
 
 
-test( "Math.ceil ( Math.LOG10E ) ", Math.ceil ( Math.LOG10E ) , 1 ); 
+test( "Math.ceil ( Math.LOG10E ) ", Math.ceil ( Math.LOG10E ) , 1 );
 
 
-test( "Math.ceil ( Math.PI ) ", Math.ceil ( Math.PI ) , 4 ); 
+test( "Math.ceil ( Math.PI ) ", Math.ceil ( Math.PI ) , 4 );
 
 
-test( "Math.ceil ( Math.SQRT1_2 ) ", Math.ceil ( Math.SQRT1_2 ) , 1 ); 
+test( "Math.ceil ( Math.SQRT1_2 ) ", Math.ceil ( Math.SQRT1_2 ) , 1 );
 
 
-test( "Math.ceil ( Math.SQRT2 ) ", Math.ceil ( Math.SQRT2 ) , 2 ); 
+test( "Math.ceil ( Math.SQRT2 ) ", Math.ceil ( Math.SQRT2 ) , 2 );
 
 
-test( "Math.ceil ( Number.POSITIVE_INFINITY ) ", Math.ceil ( Number.POSITIVE_INFINITY ) , Infinity ); 
+test( "Math.ceil ( Number.POSITIVE_INFINITY ) ", Math.ceil ( Number.POSITIVE_INFINITY ) , Infinity );
 
 
-test( "Math.ceil ( Number.NEGATIVE_INFINITY ) ", Math.ceil ( Number.NEGATIVE_INFINITY ) , -Infinity ); 
+test( "Math.ceil ( Number.NEGATIVE_INFINITY ) ", Math.ceil ( Number.NEGATIVE_INFINITY ) , -Infinity );
 
 
-test( "Math.ceil ( Number.MAX_VALUE ) ", Math.ceil ( Number.MAX_VALUE ) , Number.MAX_VALUE ); 
+test( "Math.ceil ( Number.MAX_VALUE ) ", Math.ceil ( Number.MAX_VALUE ) , Number.MAX_VALUE );
 
 
-test( "Math.ceil ( Number.MIN_VALUE ) ", Math.ceil ( Number.MIN_VALUE ) , 1 ); 
+test( "Math.ceil ( Number.MIN_VALUE ) ", Math.ceil ( Number.MIN_VALUE ) , 1 );
 
 
-test( "Math.ceil ( Number.NaN ) ", Math.ceil ( Number.NaN ) , Number.NaN ); 
+test( "Math.ceil ( Number.NaN ) ", Math.ceil ( Number.NaN ) , Number.NaN );
 
 
-test( "Math.ceil ( 0 ) ", Math.ceil ( 0 ) , 0 ); 
+test( "Math.ceil ( 0 ) ", Math.ceil ( 0 ) , 0 );
 
 
-test( "Math.ceil ( -0 ) ", Math.ceil ( -0 ) , 0 ); 
+test( "Math.ceil ( -0 ) ", Math.ceil ( -0 ) , 0 );
 
 
-test( "Math.ceil ( 1.012 ) ", Math.ceil ( 1.012 ) , 2 ); 
+test( "Math.ceil ( 1.012 ) ", Math.ceil ( 1.012 ) , 2 );
 
 
-test( "Math.ceil ( -1.12 ) ", Math.ceil ( -1.12 ) , -1 ); 
+test( "Math.ceil ( -1.12 ) ", Math.ceil ( -1.12 ) , -1 );
 
 
-test( "Math.ceil ( 1 ) ", Math.ceil ( 1 ) , 1 ); 
+test( "Math.ceil ( 1 ) ", Math.ceil ( 1 ) , 1 );
 
 
-test( "Math.ceil ( -0.5 ) ", Math.ceil ( -0.5 ) , 0 ); 
+test( "Math.ceil ( -0.5 ) ", Math.ceil ( -0.5 ) , 0 );
 
 
-test( "Math.ceil ( 0.499 ) ", Math.ceil ( 0.499 ) , 1 ); 
+test( "Math.ceil ( 0.499 ) ", Math.ceil ( 0.499 ) , 1 );
 
 
-teste( "Math.cos ( Math.E ) ", Math.cos ( Math.E ) , -0.9117339147869651 ); 
+teste( "Math.cos ( Math.E ) ", Math.cos ( Math.E ) , -0.9117339147869651 );
 
 
-teste( "Math.cos ( Math.LN2 ) ", Math.cos ( Math.LN2 ) , 0.7692389013639721 ); 
+teste( "Math.cos ( Math.LN2 ) ", Math.cos ( Math.LN2 ) , 0.7692389013639721 );
 
 
-teste( "Math.cos ( Math.LN10 ) ", Math.cos ( Math.LN10 ) , -0.6682015101903131 ); 
+teste( "Math.cos ( Math.LN10 ) ", Math.cos ( Math.LN10 ) , -0.6682015101903131 );
 
 
-teste( "Math.cos ( Math.LOG2E ) ", Math.cos ( Math.LOG2E ) , 0.12775121753523993 ); 
+teste( "Math.cos ( Math.LOG2E ) ", Math.cos ( Math.LOG2E ) , 0.12775121753523993 );
 
 
-teste( "Math.cos ( Math.LOG10E ) ", Math.cos ( Math.LOG10E ) , 0.9071671292390984 ); 
+teste( "Math.cos ( Math.LOG10E ) ", Math.cos ( Math.LOG10E ) , 0.9071671292390984 );
 
 
-teste( "Math.cos ( Math.PI ) ", Math.cos ( Math.PI ) , -1 ); 
+teste( "Math.cos ( Math.PI ) ", Math.cos ( Math.PI ) , -1 );
 
 
-teste( "Math.cos ( Math.SQRT1_2 ) ", Math.cos ( Math.SQRT1_2 ) , 0.7602445970756301 ); 
+teste( "Math.cos ( Math.SQRT1_2 ) ", Math.cos ( Math.SQRT1_2 ) , 0.7602445970756301 );
 
 
-teste( "Math.cos ( Math.SQRT2 ) ", Math.cos ( Math.SQRT2 ) , 0.15594369476537437 ); 
+teste( "Math.cos ( Math.SQRT2 ) ", Math.cos ( Math.SQRT2 ) , 0.15594369476537437 );
 
 
-test( "Math.cos ( Number.POSITIVE_INFINITY ) ", Math.cos ( Number.POSITIVE_INFINITY ) , Number.NaN ); 
+test( "Math.cos ( Number.POSITIVE_INFINITY ) ", Math.cos ( Number.POSITIVE_INFINITY ) , Number.NaN );
 
 
-test( "Math.cos ( Number.NEGATIVE_INFINITY ) ", Math.cos ( Number.NEGATIVE_INFINITY ) , Number.NaN ); 
+test( "Math.cos ( Number.NEGATIVE_INFINITY ) ", Math.cos ( Number.NEGATIVE_INFINITY ) , Number.NaN );
 
 
-/* There is some evidence that the correct answer is 0.8925373225282277.  This 
+/* There is some evidence that the correct answer is 0.8925373225282277.  This
    is based on some amateureish playing around with exact arithmetic in Scheme:
 
     > (define max-float (* (expt 2 1023) (/ (- (expt 2 53) 1) (expt 2 52))))  ; IEEE double precision
@@ -404,455 +404,455 @@ test( "Math.cos ( Number.NEGATIVE_INFINITY ) ", Math.cos ( Number.NEGATIVE_INFIN
 if (!navigator.userAgent.match(/Linux.*86/))
 	teste( "Math.cos ( Number.MAX_VALUE ) ", Math.cos ( Number.MAX_VALUE ) , 0.9057811022070704 );
 
-teste( "Math.cos ( Number.MIN_VALUE ) ", Math.cos ( Number.MIN_VALUE ) , 1 ); 
+teste( "Math.cos ( Number.MIN_VALUE ) ", Math.cos ( Number.MIN_VALUE ) , 1 );
 
 
-test( "Math.cos ( Number.NaN ) ", Math.cos ( Number.NaN ) , Number.NaN ); 
+test( "Math.cos ( Number.NaN ) ", Math.cos ( Number.NaN ) , Number.NaN );
 
 
-teste( "Math.cos ( 0 ) ", Math.cos ( 0 ) , 1 ); 
+teste( "Math.cos ( 0 ) ", Math.cos ( 0 ) , 1 );
 
 
-teste( "Math.cos ( -0 ) ", Math.cos ( -0 ) , 1 ); 
+teste( "Math.cos ( -0 ) ", Math.cos ( -0 ) , 1 );
 
 
-teste( "Math.cos ( 1.012 ) ", Math.cos ( 1.012 ) , 0.5301659950931401 ); 
+teste( "Math.cos ( 1.012 ) ", Math.cos ( 1.012 ) , 0.5301659950931401 );
 
 
-teste( "Math.cos ( -1.12 ) ", Math.cos ( -1.12 ) , 0.4356824462767121 ); 
+teste( "Math.cos ( -1.12 ) ", Math.cos ( -1.12 ) , 0.4356824462767121 );
 
 
-teste( "Math.cos ( 1 ) ", Math.cos ( 1 ) , 0.5403023058681398 ); 
+teste( "Math.cos ( 1 ) ", Math.cos ( 1 ) , 0.5403023058681398 );
 
 
-teste( "Math.cos ( -0.5 ) ", Math.cos ( -0.5 ) , 0.8775825618903728 ); 
+teste( "Math.cos ( -0.5 ) ", Math.cos ( -0.5 ) , 0.8775825618903728 );
 
 
-teste( "Math.cos ( 0.499 ) ", Math.cos ( 0.499 ) , 0.8780615485578282 ); 
+teste( "Math.cos ( 0.499 ) ", Math.cos ( 0.499 ) , 0.8780615485578282 );
 
 
-teste( "Math.exp ( Math.E ) ", Math.exp ( Math.E ) , 15.154262241479262 ); 
+teste( "Math.exp ( Math.E ) ", Math.exp ( Math.E ) , 15.154262241479262 );
 
 
-test( "Math.exp ( Math.LN2 ) ", Math.exp ( Math.LN2 ) , 2 ); 
+test( "Math.exp ( Math.LN2 ) ", Math.exp ( Math.LN2 ) , 2 );
 
 
-teste( "Math.exp ( Math.LN10 ) ", Math.exp ( Math.LN10 ) , 10.000000000000001 ); 
+teste( "Math.exp ( Math.LN10 ) ", Math.exp ( Math.LN10 ) , 10.000000000000001 );
 
 
-teste( "Math.exp ( Math.LOG2E ) ", Math.exp ( Math.LOG2E ) , 4.232086106557082 ); 
+teste( "Math.exp ( Math.LOG2E ) ", Math.exp ( Math.LOG2E ) , 4.232086106557082 );
 
 
-teste( "Math.exp ( Math.LOG10E ) ", Math.exp ( Math.LOG10E ) , 1.5438734439711812 ); 
+teste( "Math.exp ( Math.LOG10E ) ", Math.exp ( Math.LOG10E ) , 1.5438734439711812 );
 
 
-teste( "Math.exp ( Math.PI ) ", Math.exp ( Math.PI ) , 23.140692632779267 ); 
+teste( "Math.exp ( Math.PI ) ", Math.exp ( Math.PI ) , 23.140692632779267 );
 
 
-teste( "Math.exp ( Math.SQRT1_2 ) ", Math.exp ( Math.SQRT1_2 ) , 2.0281149816474726 ); 
+teste( "Math.exp ( Math.SQRT1_2 ) ", Math.exp ( Math.SQRT1_2 ) , 2.0281149816474726 );
 
 
-teste( "Math.exp ( Math.SQRT2 ) ", Math.exp ( Math.SQRT2 ) , 4.1132503787829275 ); 
+teste( "Math.exp ( Math.SQRT2 ) ", Math.exp ( Math.SQRT2 ) , 4.1132503787829275 );
 
 
-test( "Math.exp ( Number.POSITIVE_INFINITY ) ", Math.exp ( Number.POSITIVE_INFINITY ) , Infinity ); 
+test( "Math.exp ( Number.POSITIVE_INFINITY ) ", Math.exp ( Number.POSITIVE_INFINITY ) , Infinity );
 
 
-test( "Math.exp ( Number.NEGATIVE_INFINITY ) ", Math.exp ( Number.NEGATIVE_INFINITY ) , 0 ); 
+test( "Math.exp ( Number.NEGATIVE_INFINITY ) ", Math.exp ( Number.NEGATIVE_INFINITY ) , 0 );
 
 
-test( "Math.exp ( Number.MAX_VALUE ) ", Math.exp ( Number.MAX_VALUE ) , Infinity ); 
+test( "Math.exp ( Number.MAX_VALUE ) ", Math.exp ( Number.MAX_VALUE ) , Infinity );
 
 
-test( "Math.exp ( Number.MIN_VALUE ) ", Math.exp ( Number.MIN_VALUE ) , 1 ); 
+test( "Math.exp ( Number.MIN_VALUE ) ", Math.exp ( Number.MIN_VALUE ) , 1 );
 
 
-test( "Math.exp ( Number.NaN ) ", Math.exp ( Number.NaN ) , Number.NaN ); 
+test( "Math.exp ( Number.NaN ) ", Math.exp ( Number.NaN ) , Number.NaN );
 
 
-test( "Math.exp ( 0 ) ", Math.exp ( 0 ) , 1 ); 
+test( "Math.exp ( 0 ) ", Math.exp ( 0 ) , 1 );
 
 
-test( "Math.exp ( -0 ) ", Math.exp ( -0 ) , 1 ); 
+test( "Math.exp ( -0 ) ", Math.exp ( -0 ) , 1 );
 
 
-teste( "Math.exp ( 1.012 ) ", Math.exp ( 1.012 ) , 2.751097711911613 ); 
+teste( "Math.exp ( 1.012 ) ", Math.exp ( 1.012 ) , 2.751097711911613 );
 
 
-teste( "Math.exp ( -1.12 ) ", Math.exp ( -1.12 ) , 0.32627979462303946 ); 
+teste( "Math.exp ( -1.12 ) ", Math.exp ( -1.12 ) , 0.32627979462303946 );
 
 
-test( "Math.exp ( 1 ) ", Math.exp ( 1 ) , Math.E ); 
+test( "Math.exp ( 1 ) ", Math.exp ( 1 ) , Math.E );
 
 
-teste( "Math.exp ( -0.5 ) ", Math.exp ( -0.5 ) , 0.6065306597126334 ); 
+teste( "Math.exp ( -0.5 ) ", Math.exp ( -0.5 ) , 0.6065306597126334 );
 
 
-teste( "Math.exp ( 0.499 ) ", Math.exp ( 0.499 ) , 1.647073373515345 ); 
+teste( "Math.exp ( 0.499 ) ", Math.exp ( 0.499 ) , 1.647073373515345 );
 
 
-test( "Math.floor ( Math.E ) ", Math.floor ( Math.E ) , 2 ); 
+test( "Math.floor ( Math.E ) ", Math.floor ( Math.E ) , 2 );
 
 
-test( "Math.floor ( Math.LN2 ) ", Math.floor ( Math.LN2 ) , 0 ); 
+test( "Math.floor ( Math.LN2 ) ", Math.floor ( Math.LN2 ) , 0 );
 
 
-test( "Math.floor ( Math.LN10 ) ", Math.floor ( Math.LN10 ) , 2 ); 
+test( "Math.floor ( Math.LN10 ) ", Math.floor ( Math.LN10 ) , 2 );
 
 
-test( "Math.floor ( Math.LOG2E ) ", Math.floor ( Math.LOG2E ) , 1 ); 
+test( "Math.floor ( Math.LOG2E ) ", Math.floor ( Math.LOG2E ) , 1 );
 
 
-test( "Math.floor ( Math.LOG10E ) ", Math.floor ( Math.LOG10E ) , 0 ); 
+test( "Math.floor ( Math.LOG10E ) ", Math.floor ( Math.LOG10E ) , 0 );
 
 
-test( "Math.floor ( Math.PI ) ", Math.floor ( Math.PI ) , 3 ); 
+test( "Math.floor ( Math.PI ) ", Math.floor ( Math.PI ) , 3 );
 
 
-test( "Math.floor ( Math.SQRT1_2 ) ", Math.floor ( Math.SQRT1_2 ) , 0 ); 
+test( "Math.floor ( Math.SQRT1_2 ) ", Math.floor ( Math.SQRT1_2 ) , 0 );
 
 
-test( "Math.floor ( Math.SQRT2 ) ", Math.floor ( Math.SQRT2 ) , 1 ); 
+test( "Math.floor ( Math.SQRT2 ) ", Math.floor ( Math.SQRT2 ) , 1 );
 
 
-test( "Math.floor ( Number.POSITIVE_INFINITY ) ", Math.floor ( Number.POSITIVE_INFINITY ) , Infinity ); 
+test( "Math.floor ( Number.POSITIVE_INFINITY ) ", Math.floor ( Number.POSITIVE_INFINITY ) , Infinity );
 
 
-test( "Math.floor ( Number.NEGATIVE_INFINITY ) ", Math.floor ( Number.NEGATIVE_INFINITY ) , -Infinity ); 
+test( "Math.floor ( Number.NEGATIVE_INFINITY ) ", Math.floor ( Number.NEGATIVE_INFINITY ) , -Infinity );
 
 
-teste( "Math.floor ( Number.MAX_VALUE ) ", Math.floor ( Number.MAX_VALUE ) , Number.MAX_VALUE ); 
+teste( "Math.floor ( Number.MAX_VALUE ) ", Math.floor ( Number.MAX_VALUE ) , Number.MAX_VALUE );
 
 
-test( "Math.floor ( Number.MIN_VALUE ) ", Math.floor ( Number.MIN_VALUE ) , 0 ); 
+test( "Math.floor ( Number.MIN_VALUE ) ", Math.floor ( Number.MIN_VALUE ) , 0 );
 
 
-test( "Math.floor ( Number.NaN ) ", Math.floor ( Number.NaN ) , Number.NaN ); 
+test( "Math.floor ( Number.NaN ) ", Math.floor ( Number.NaN ) , Number.NaN );
 
 
-test( "Math.floor ( 0 ) ", Math.floor ( 0 ) , 0 ); 
+test( "Math.floor ( 0 ) ", Math.floor ( 0 ) , 0 );
 
 
-test( "Math.floor ( -0 ) ", Math.floor ( -0 ) , 0 ); 
+test( "Math.floor ( -0 ) ", Math.floor ( -0 ) , 0 );
 
 
-test( "Math.floor ( 1.012 ) ", Math.floor ( 1.012 ) , 1 ); 
+test( "Math.floor ( 1.012 ) ", Math.floor ( 1.012 ) , 1 );
 
 
-test( "Math.floor ( -1.12 ) ", Math.floor ( -1.12 ) , -2 ); 
+test( "Math.floor ( -1.12 ) ", Math.floor ( -1.12 ) , -2 );
 
 
-test( "Math.floor ( 1 ) ", Math.floor ( 1 ) , 1 ); 
+test( "Math.floor ( 1 ) ", Math.floor ( 1 ) , 1 );
 
 
-test( "Math.floor ( -0.5 ) ", Math.floor ( -0.5 ) , -1 ); 
+test( "Math.floor ( -0.5 ) ", Math.floor ( -0.5 ) , -1 );
 
 
-test( "Math.floor ( 0.499 ) ", Math.floor ( 0.499 ) , 0 ); 
+test( "Math.floor ( 0.499 ) ", Math.floor ( 0.499 ) , 0 );
 
 
-teste( "Math.log ( Math.E ) ", Math.log ( Math.E ) , 1 ); 
+teste( "Math.log ( Math.E ) ", Math.log ( Math.E ) , 1 );
 
 
-teste( "Math.log ( Math.LN2 ) ", Math.log ( Math.LN2 ) , -0.36651292058166434 ); 
+teste( "Math.log ( Math.LN2 ) ", Math.log ( Math.LN2 ) , -0.36651292058166434 );
 
 
-teste( "Math.log ( Math.LN10 ) ", Math.log ( Math.LN10 ) , 0.834032445247956 ); 
+teste( "Math.log ( Math.LN10 ) ", Math.log ( Math.LN10 ) , 0.834032445247956 );
 
 
-teste( "Math.log ( Math.LOG2E ) ", Math.log ( Math.LOG2E ) , 0.3665129205816643 ); 
+teste( "Math.log ( Math.LOG2E ) ", Math.log ( Math.LOG2E ) , 0.3665129205816643 );
 
 
-teste( "Math.log ( Math.LOG10E ) ", Math.log ( Math.LOG10E ) , -0.8340324452479558 ); 
+teste( "Math.log ( Math.LOG10E ) ", Math.log ( Math.LOG10E ) , -0.8340324452479558 );
 
 
-teste( "Math.log ( Math.PI ) ", Math.log ( Math.PI ) , 1.1447298858494001 ); 
+teste( "Math.log ( Math.PI ) ", Math.log ( Math.PI ) , 1.1447298858494001 );
 
 
-teste( "Math.log ( Math.SQRT1_2 ) ", Math.log ( Math.SQRT1_2 ) , -0.3465735902799726 ); 
+teste( "Math.log ( Math.SQRT1_2 ) ", Math.log ( Math.SQRT1_2 ) , -0.3465735902799726 );
 
 
-teste( "Math.log ( Math.SQRT2 ) ", Math.log ( Math.SQRT2 ) , 0.3465735902799727 ); 
+teste( "Math.log ( Math.SQRT2 ) ", Math.log ( Math.SQRT2 ) , 0.3465735902799727 );
 
 
-test( "Math.log ( Number.POSITIVE_INFINITY ) ", Math.log ( Number.POSITIVE_INFINITY ) , Infinity ); 
+test( "Math.log ( Number.POSITIVE_INFINITY ) ", Math.log ( Number.POSITIVE_INFINITY ) , Infinity );
 
 
-test( "Math.log ( Number.NEGATIVE_INFINITY ) ", Math.log ( Number.NEGATIVE_INFINITY ) , Number.NaN ); 
+test( "Math.log ( Number.NEGATIVE_INFINITY ) ", Math.log ( Number.NEGATIVE_INFINITY ) , Number.NaN );
 
 
-teste( "Math.log ( Number.MAX_VALUE ) ", Math.log ( Number.MAX_VALUE ) , 709.782712893384 ); 
+teste( "Math.log ( Number.MAX_VALUE ) ", Math.log ( Number.MAX_VALUE ) , 709.782712893384 );
 
 
-teste( "Math.log ( Number.MIN_VALUE ) ", Math.log ( Number.MIN_VALUE ) , -744.4400719213812 ); 
+teste( "Math.log ( Number.MIN_VALUE ) ", Math.log ( Number.MIN_VALUE ) , -744.4400719213812 );
 
 
-test( "Math.log ( Number.NaN ) ", Math.log ( Number.NaN ) , Number.NaN ); 
+test( "Math.log ( Number.NaN ) ", Math.log ( Number.NaN ) , Number.NaN );
 
 
-test( "Math.log ( 0 ) ", Math.log ( 0 ) , -Infinity ); 
+test( "Math.log ( 0 ) ", Math.log ( 0 ) , -Infinity );
 
 
-test( "Math.log ( -0 ) ", Math.log ( -0 ) , -Infinity ); 
+test( "Math.log ( -0 ) ", Math.log ( -0 ) , -Infinity );
 
 
-teste( "Math.log ( 1.012 ) ", Math.log ( 1.012 ) , 0.011928570865273812 ); 
+teste( "Math.log ( 1.012 ) ", Math.log ( 1.012 ) , 0.011928570865273812 );
 
 
-test( "Math.log ( -1.12 ) ", Math.log ( -1.12 ) , Number.NaN ); 
+test( "Math.log ( -1.12 ) ", Math.log ( -1.12 ) , Number.NaN );
 
 
-test( "Math.log ( 1 ) ", Math.log ( 1 ) , 0 ); 
+test( "Math.log ( 1 ) ", Math.log ( 1 ) , 0 );
 
 
-test( "Math.log ( -0.5 ) ", Math.log ( -0.5 ) , Number.NaN ); 
+test( "Math.log ( -0.5 ) ", Math.log ( -0.5 ) , Number.NaN );
 
 
-teste( "Math.log ( 0.499 ) ", Math.log ( 0.499 ) , -0.6951491832306184 ); 
+teste( "Math.log ( 0.499 ) ", Math.log ( 0.499 ) , -0.6951491832306184 );
 
 
-test( "Math.round ( Math.E ) ", Math.round ( Math.E ) , 3 ); 
+test( "Math.round ( Math.E ) ", Math.round ( Math.E ) , 3 );
 
 
-test( "Math.round ( Math.LN2 ) ", Math.round ( Math.LN2 ) , 1 ); 
+test( "Math.round ( Math.LN2 ) ", Math.round ( Math.LN2 ) , 1 );
 
 
-test( "Math.round ( Math.LN10 ) ", Math.round ( Math.LN10 ) , 2 ); 
+test( "Math.round ( Math.LN10 ) ", Math.round ( Math.LN10 ) , 2 );
 
 
-test( "Math.round ( Math.LOG2E ) ", Math.round ( Math.LOG2E ) , 1 ); 
+test( "Math.round ( Math.LOG2E ) ", Math.round ( Math.LOG2E ) , 1 );
 
 
-test( "Math.round ( Math.LOG10E ) ", Math.round ( Math.LOG10E ) , 0 ); 
+test( "Math.round ( Math.LOG10E ) ", Math.round ( Math.LOG10E ) , 0 );
 
 
-test( "Math.round ( Math.PI ) ", Math.round ( Math.PI ) , 3 ); 
+test( "Math.round ( Math.PI ) ", Math.round ( Math.PI ) , 3 );
 
 
-test( "Math.round ( Math.SQRT1_2 ) ", Math.round ( Math.SQRT1_2 ) , 1 ); 
+test( "Math.round ( Math.SQRT1_2 ) ", Math.round ( Math.SQRT1_2 ) , 1 );
 
 
-test( "Math.round ( Math.SQRT2 ) ", Math.round ( Math.SQRT2 ) , 1 ); 
+test( "Math.round ( Math.SQRT2 ) ", Math.round ( Math.SQRT2 ) , 1 );
 
 
-test( "Math.round ( Number.POSITIVE_INFINITY ) ", Math.round ( Number.POSITIVE_INFINITY ) , Infinity ); 
+test( "Math.round ( Number.POSITIVE_INFINITY ) ", Math.round ( Number.POSITIVE_INFINITY ) , Infinity );
 
 
-test( "Math.round ( Number.NEGATIVE_INFINITY ) ", Math.round ( Number.NEGATIVE_INFINITY ) , -Infinity ); 
+test( "Math.round ( Number.NEGATIVE_INFINITY ) ", Math.round ( Number.NEGATIVE_INFINITY ) , -Infinity );
 
 
-test( "Math.round ( Number.MAX_VALUE ) ", Math.round ( Number.MAX_VALUE ) , Number.MAX_VALUE ); 
+test( "Math.round ( Number.MAX_VALUE ) ", Math.round ( Number.MAX_VALUE ) , Number.MAX_VALUE );
 
 
-test( "Math.round ( Number.MIN_VALUE ) ", Math.round ( Number.MIN_VALUE ) , 0 ); 
+test( "Math.round ( Number.MIN_VALUE ) ", Math.round ( Number.MIN_VALUE ) , 0 );
 
 
-test( "Math.round ( Number.NaN ) ", Math.round ( Number.NaN ) , Number.NaN ); 
+test( "Math.round ( Number.NaN ) ", Math.round ( Number.NaN ) , Number.NaN );
 
 
-test( "Math.round ( 0 ) ", Math.round ( 0 ) , 0 ); 
+test( "Math.round ( 0 ) ", Math.round ( 0 ) , 0 );
 
 
-test( "Math.round ( -0 ) ", Math.round ( -0 ) , 0 ); 
+test( "Math.round ( -0 ) ", Math.round ( -0 ) , 0 );
 
 
-test( "Math.round ( 1.012 ) ", Math.round ( 1.012 ) , 1 ); 
+test( "Math.round ( 1.012 ) ", Math.round ( 1.012 ) , 1 );
 
 
-test( "Math.round ( -1.12 ) ", Math.round ( -1.12 ) , -1 ); 
+test( "Math.round ( -1.12 ) ", Math.round ( -1.12 ) , -1 );
 
 
-test( "Math.round ( 1 ) ", Math.round ( 1 ) , 1 ); 
+test( "Math.round ( 1 ) ", Math.round ( 1 ) , 1 );
 
 
-test( "Math.round ( -0.5 ) ", Math.round ( -0.5 ) , 0 ); 
+test( "Math.round ( -0.5 ) ", Math.round ( -0.5 ) , 0 );
 
 
-test( "Math.round ( 0.499 ) ", Math.round ( 0.499 ) , 0 ); 
+test( "Math.round ( 0.499 ) ", Math.round ( 0.499 ) , 0 );
 
 
-teste( "Math.sin ( Math.E ) ", Math.sin ( Math.E ) , 0.41078129050290884 ); 
+teste( "Math.sin ( Math.E ) ", Math.sin ( Math.E ) , 0.41078129050290884 );
 
 
-teste( "Math.sin ( Math.LN2 ) ", Math.sin ( Math.LN2 ) , 0.6389612763136347 ); 
+teste( "Math.sin ( Math.LN2 ) ", Math.sin ( Math.LN2 ) , 0.6389612763136347 );
 
 
-teste( "Math.sin ( Math.LN10 ) ", Math.sin ( Math.LN10 ) , 0.743980336957493 ); 
+teste( "Math.sin ( Math.LN10 ) ", Math.sin ( Math.LN10 ) , 0.743980336957493 );
 
 
-teste( "Math.sin ( Math.LOG2E ) ", Math.sin ( Math.LOG2E ) , 0.9918062443936637 ); 
+teste( "Math.sin ( Math.LOG2E ) ", Math.sin ( Math.LOG2E ) , 0.9918062443936637 );
 
 
-teste( "Math.sin ( Math.LOG10E ) ", Math.sin ( Math.LOG10E ) , 0.4207704833137573 ); 
+teste( "Math.sin ( Math.LOG10E ) ", Math.sin ( Math.LOG10E ) , 0.4207704833137573 );
 
 
-teste( "Math.sin ( Math.PI ) ", Math.sin ( Math.PI ) , 1.2246063538223772e-16 ); 
+teste( "Math.sin ( Math.PI ) ", Math.sin ( Math.PI ) , 1.2246063538223772e-16 );
 
 
-teste( "Math.sin ( Math.SQRT1_2 ) ", Math.sin ( Math.SQRT1_2 ) , 0.6496369390800625 ); 
+teste( "Math.sin ( Math.SQRT1_2 ) ", Math.sin ( Math.SQRT1_2 ) , 0.6496369390800625 );
 
 
-teste( "Math.sin ( Math.SQRT2 ) ", Math.sin ( Math.SQRT2 ) , 0.9877659459927356 ); 
+teste( "Math.sin ( Math.SQRT2 ) ", Math.sin ( Math.SQRT2 ) , 0.9877659459927356 );
 
 
-test( "Math.sin ( Number.POSITIVE_INFINITY ) ", Math.sin ( Number.POSITIVE_INFINITY ) , Number.NaN ); 
+test( "Math.sin ( Number.POSITIVE_INFINITY ) ", Math.sin ( Number.POSITIVE_INFINITY ) , Number.NaN );
 
 
-test( "Math.sin ( Number.NEGATIVE_INFINITY ) ", Math.sin ( Number.NEGATIVE_INFINITY ) , Number.NaN ); 
+test( "Math.sin ( Number.NEGATIVE_INFINITY ) ", Math.sin ( Number.NEGATIVE_INFINITY ) , Number.NaN );
 
 
 /* See comments for Math.cos above */
 if (!navigator.userAgent.match(/Linux.*86/))
-	teste( "Math.sin ( Number.MAX_VALUE ) ", Math.sin ( Number.MAX_VALUE ) , -0.42374590839858816 ); 
+	teste( "Math.sin ( Number.MAX_VALUE ) ", Math.sin ( Number.MAX_VALUE ) , -0.42374590839858816 );
 
 
-teste( "Math.sin ( Number.MIN_VALUE ) ", Math.sin ( Number.MIN_VALUE ) , 5e-324 ); 
+teste( "Math.sin ( Number.MIN_VALUE ) ", Math.sin ( Number.MIN_VALUE ) , 5e-324 );
 
 
-test( "Math.sin ( Number.NaN ) ", Math.sin ( Number.NaN ) , Number.NaN ); 
+test( "Math.sin ( Number.NaN ) ", Math.sin ( Number.NaN ) , Number.NaN );
 
 
-test( "Math.sin ( 0 ) ", Math.sin ( 0 ) , 0 ); 
+test( "Math.sin ( 0 ) ", Math.sin ( 0 ) , 0 );
 
 
-test( "Math.sin ( -0 ) ", Math.sin ( -0 ) , 0 ); 
+test( "Math.sin ( -0 ) ", Math.sin ( -0 ) , 0 );
 
 
-teste( "Math.sin ( 1.012 ) ", Math.sin ( 1.012 ) , 0.8478938716884917 ); 
+teste( "Math.sin ( 1.012 ) ", Math.sin ( 1.012 ) , 0.8478938716884917 );
 
 
-teste( "Math.sin ( -1.12 ) ", Math.sin ( -1.12 ) , -0.9001004421765051 ); 
+teste( "Math.sin ( -1.12 ) ", Math.sin ( -1.12 ) , -0.9001004421765051 );
 
 
-teste( "Math.sin ( 1 ) ", Math.sin ( 1 ) , 0.8414709848078965 ); 
+teste( "Math.sin ( 1 ) ", Math.sin ( 1 ) , 0.8414709848078965 );
 
 
-teste( "Math.sin ( -0.5 ) ", Math.sin ( -0.5 ) , -0.479425538604203 ); 
+teste( "Math.sin ( -0.5 ) ", Math.sin ( -0.5 ) , -0.479425538604203 );
 
 
-teste( "Math.sin ( 0.499 ) ", Math.sin ( 0.499 ) , 0.47854771647582705 ); 
+teste( "Math.sin ( 0.499 ) ", Math.sin ( 0.499 ) , 0.47854771647582705 );
 
 
-teste( "Math.sqrt ( Math.E ) ", Math.sqrt ( Math.E ) , 1.6487212707001282 ); 
+teste( "Math.sqrt ( Math.E ) ", Math.sqrt ( Math.E ) , 1.6487212707001282 );
 
 
-teste( "Math.sqrt ( Math.LN2 ) ", Math.sqrt ( Math.LN2 ) , 0.8325546111576977 ); 
+teste( "Math.sqrt ( Math.LN2 ) ", Math.sqrt ( Math.LN2 ) , 0.8325546111576977 );
 
 
-teste( "Math.sqrt ( Math.LN10 ) ", Math.sqrt ( Math.LN10 ) , 1.5174271293851464 ); 
+teste( "Math.sqrt ( Math.LN10 ) ", Math.sqrt ( Math.LN10 ) , 1.5174271293851464 );
 
 
-teste( "Math.sqrt ( Math.LOG2E ) ", Math.sqrt ( Math.LOG2E ) , 1.2011224087864498 ); 
+teste( "Math.sqrt ( Math.LOG2E ) ", Math.sqrt ( Math.LOG2E ) , 1.2011224087864498 );
 
 
-teste( "Math.sqrt ( Math.LOG10E ) ", Math.sqrt ( Math.LOG10E ) , 0.6590102289822608 ); 
+teste( "Math.sqrt ( Math.LOG10E ) ", Math.sqrt ( Math.LOG10E ) , 0.6590102289822608 );
 
 
-teste( "Math.sqrt ( Math.PI ) ", Math.sqrt ( Math.PI ) , 1.7724538509055158 ); 
+teste( "Math.sqrt ( Math.PI ) ", Math.sqrt ( Math.PI ) , 1.7724538509055158 );
 
 
-teste( "Math.sqrt ( Math.SQRT1_2 ) ", Math.sqrt ( Math.SQRT1_2 ) , 0.8408964152537146 ); 
+teste( "Math.sqrt ( Math.SQRT1_2 ) ", Math.sqrt ( Math.SQRT1_2 ) , 0.8408964152537146 );
 
 
-teste( "Math.sqrt ( Math.SQRT2 ) ", Math.sqrt ( Math.SQRT2 ) , 1.189207115002721 ); 
+teste( "Math.sqrt ( Math.SQRT2 ) ", Math.sqrt ( Math.SQRT2 ) , 1.189207115002721 );
 
 
-test( "Math.sqrt ( Number.POSITIVE_INFINITY ) ", Math.sqrt ( Number.POSITIVE_INFINITY ) , Infinity ); 
+test( "Math.sqrt ( Number.POSITIVE_INFINITY ) ", Math.sqrt ( Number.POSITIVE_INFINITY ) , Infinity );
 
 
-test( "Math.sqrt ( Number.NEGATIVE_INFINITY ) ", Math.sqrt ( Number.NEGATIVE_INFINITY ) , Number.NaN ); 
+test( "Math.sqrt ( Number.NEGATIVE_INFINITY ) ", Math.sqrt ( Number.NEGATIVE_INFINITY ) , Number.NaN );
 
 
-teste( "Math.sqrt ( Number.MAX_VALUE ) ", Math.sqrt ( Number.MAX_VALUE ) , 1.3407807929942595e+154 ); 
+teste( "Math.sqrt ( Number.MAX_VALUE ) ", Math.sqrt ( Number.MAX_VALUE ) , 1.3407807929942595e+154 );
 
 
-teste( "Math.sqrt ( Number.MIN_VALUE ) ", Math.sqrt ( Number.MIN_VALUE ) , 2.2227587494850775e-162 ); 
+teste( "Math.sqrt ( Number.MIN_VALUE ) ", Math.sqrt ( Number.MIN_VALUE ) , 2.2227587494850775e-162 );
 
 
-test( "Math.sqrt ( Number.NaN ) ", Math.sqrt ( Number.NaN ) , Number.NaN ); 
+test( "Math.sqrt ( Number.NaN ) ", Math.sqrt ( Number.NaN ) , Number.NaN );
 
 
-test( "Math.sqrt ( 0 ) ", Math.sqrt ( 0 ) , 0 ); 
+test( "Math.sqrt ( 0 ) ", Math.sqrt ( 0 ) , 0 );
 
 
-test( "Math.sqrt ( -0 ) ", Math.sqrt ( -0 ) , 0 ); 
+test( "Math.sqrt ( -0 ) ", Math.sqrt ( -0 ) , 0 );
 
 
-teste( "Math.sqrt ( 1.012 ) ", Math.sqrt ( 1.012 ) , 1.0059821071967434 ); 
+teste( "Math.sqrt ( 1.012 ) ", Math.sqrt ( 1.012 ) , 1.0059821071967434 );
 
 
-test( "Math.sqrt ( -1.12 ) ", Math.sqrt ( -1.12 ) , Number.NaN ); 
+test( "Math.sqrt ( -1.12 ) ", Math.sqrt ( -1.12 ) , Number.NaN );
 
 
-test( "Math.sqrt ( 1 ) ", Math.sqrt ( 1 ) , 1 ); 
+test( "Math.sqrt ( 1 ) ", Math.sqrt ( 1 ) , 1 );
 
 
-test( "Math.sqrt ( -0.5 ) ", Math.sqrt ( -0.5 ) , Number.NaN ); 
+test( "Math.sqrt ( -0.5 ) ", Math.sqrt ( -0.5 ) , Number.NaN );
 
 
-teste( "Math.sqrt ( 0.499 ) ", Math.sqrt ( 0.499 ) , 0.7063993204979744 ); 
+teste( "Math.sqrt ( 0.499 ) ", Math.sqrt ( 0.499 ) , 0.7063993204979744 );
 
 
-teste( "Math.tan ( Math.E ) ", Math.tan ( Math.E ) , -0.4505495340698077 ); 
+teste( "Math.tan ( Math.E ) ", Math.tan ( Math.E ) , -0.4505495340698077 );
 
 
-teste( "Math.tan ( Math.LN2 ) ", Math.tan ( Math.LN2 ) , 0.8306408778607839 ); 
+teste( "Math.tan ( Math.LN2 ) ", Math.tan ( Math.LN2 ) , 0.8306408778607839 );
 
 
-teste( "Math.tan ( Math.LN10 ) ", Math.tan ( Math.LN10 ) , -1.113407146813537 ); 
+teste( "Math.tan ( Math.LN10 ) ", Math.tan ( Math.LN10 ) , -1.113407146813537 );
 
 
-teste( "Math.tan ( Math.LOG2E ) ", Math.tan ( Math.LOG2E ) , 7.763575670972184 ); 
+teste( "Math.tan ( Math.LOG2E ) ", Math.tan ( Math.LOG2E ) , 7.763575670972184 );
 
 
-teste( "Math.tan ( Math.LOG10E ) ", Math.tan ( Math.LOG10E ) , 0.4638290671606296 ); 
+teste( "Math.tan ( Math.LOG10E ) ", Math.tan ( Math.LOG10E ) , 0.4638290671606296 );
 
 
-teste( "Math.tan ( Math.PI ) ", Math.tan ( Math.PI ) , -1.2246063538223772e-16 ); 
+teste( "Math.tan ( Math.PI ) ", Math.tan ( Math.PI ) , -1.2246063538223772e-16 );
 
 
-teste( "Math.tan ( Math.SQRT1_2 ) ", Math.tan ( Math.SQRT1_2 ) , 0.854510432009602 ); 
+teste( "Math.tan ( Math.SQRT1_2 ) ", Math.tan ( Math.SQRT1_2 ) , 0.854510432009602 );
 
 
-teste( "Math.tan ( Math.SQRT2 ) ", Math.tan ( Math.SQRT2 ) , 6.3341191670421955 ); 
+teste( "Math.tan ( Math.SQRT2 ) ", Math.tan ( Math.SQRT2 ) , 6.3341191670421955 );
 
 
-test( "Math.tan ( Number.POSITIVE_INFINITY ) ", Math.tan ( Number.POSITIVE_INFINITY ) , Number.NaN ); 
+test( "Math.tan ( Number.POSITIVE_INFINITY ) ", Math.tan ( Number.POSITIVE_INFINITY ) , Number.NaN );
 
 
-test( "Math.tan ( Number.NEGATIVE_INFINITY ) ", Math.tan ( Number.NEGATIVE_INFINITY ) , Number.NaN ); 
+test( "Math.tan ( Number.NEGATIVE_INFINITY ) ", Math.tan ( Number.NEGATIVE_INFINITY ) , Number.NaN );
 
 
 /* See comments for Math.cos above */
 if (!navigator.userAgent.match(/Linux.*86/))
-	teste( "Math.tan ( Number.MAX_VALUE ) ", Math.tan ( Number.MAX_VALUE ) , -0.46782374611930877 ); 
+	teste( "Math.tan ( Number.MAX_VALUE ) ", Math.tan ( Number.MAX_VALUE ) , -0.46782374611930877 );
 
 
-teste( "Math.tan ( Number.MIN_VALUE ) ", Math.tan ( Number.MIN_VALUE ) , 5e-324 ); 
+teste( "Math.tan ( Number.MIN_VALUE ) ", Math.tan ( Number.MIN_VALUE ) , 5e-324 );
 
 
-test( "Math.tan ( Number.NaN ) ", Math.tan ( Number.NaN ) , Number.NaN ); 
+test( "Math.tan ( Number.NaN ) ", Math.tan ( Number.NaN ) , Number.NaN );
 
 
-test( "Math.tan ( 0 ) ", Math.tan ( 0 ) , 0 ); 
+test( "Math.tan ( 0 ) ", Math.tan ( 0 ) , 0 );
 
 
-test( "Math.tan ( -0 ) ", Math.tan ( -0 ) , 0 ); 
+test( "Math.tan ( -0 ) ", Math.tan ( -0 ) , 0 );
 
 
-teste( "Math.tan ( 1.012 ) ", Math.tan ( 1.012 ) , 1.599298860236279 ); 
+teste( "Math.tan ( 1.012 ) ", Math.tan ( 1.012 ) , 1.599298860236279 );
 
 
-teste( "Math.tan ( -1.12 ) ", Math.tan ( -1.12 ) , -2.0659552613805107 ); 
+teste( "Math.tan ( -1.12 ) ", Math.tan ( -1.12 ) , -2.0659552613805107 );
 
 
-teste( "Math.tan ( 1 ) ", Math.tan ( 1 ) , 1.5574077246549023 ); 
+teste( "Math.tan ( 1 ) ", Math.tan ( 1 ) , 1.5574077246549023 );
 
 
-teste( "Math.tan ( -0.5 ) ", Math.tan ( -0.5 ) , -0.5463024898437905 ); 
+teste( "Math.tan ( -0.5 ) ", Math.tan ( -0.5 ) , -0.5463024898437905 );
 
 
-teste( "Math.tan ( 0.499 ) ", Math.tan ( 0.499 ) , 0.5450047519582397 ); 
+teste( "Math.tan ( 0.499 ) ", Math.tan ( 0.499 ) , 0.5450047519582397 );
 
 
 
@@ -861,1757 +861,1757 @@ teste( "Math.tan ( 0.499 ) ", Math.tan ( 0.499 ) , 0.5450047519582397 );
 
 
 
-teste( "Math.atan2 ( Number.POSITIVE_INFINITY, Number.POSITIVE_INFINITY ) ", 
-      Math.atan2 ( Number.POSITIVE_INFINITY, Number.POSITIVE_INFINITY ) , 0.7853981633974483 ); 
+teste( "Math.atan2 ( Number.POSITIVE_INFINITY, Number.POSITIVE_INFINITY ) ",
+      Math.atan2 ( Number.POSITIVE_INFINITY, Number.POSITIVE_INFINITY ) , 0.7853981633974483 );
 /* ECMA: If y is +Infinity and x is +Infinity, the result is an implementation-dependent approximation to +PI/4. */
 
-teste( "Math.atan2 ( Number.POSITIVE_INFINITY, Number.NEGATIVE_INFINITY ) ", 
-      Math.atan2 ( Number.POSITIVE_INFINITY, Number.NEGATIVE_INFINITY ) , 2.356194490192345 ); 
+teste( "Math.atan2 ( Number.POSITIVE_INFINITY, Number.NEGATIVE_INFINITY ) ",
+      Math.atan2 ( Number.POSITIVE_INFINITY, Number.NEGATIVE_INFINITY ) , 2.356194490192345 );
 /* ECMA: If y is +Infinity and x is -Infinity, the result is an implementation-dependent approximation to +PI/4. */
 
 
-teste( "Math.atan2 ( Number.POSITIVE_INFINITY, Number.MAX_VALUE ) ", 
-      Math.atan2 ( Number.POSITIVE_INFINITY, Number.MAX_VALUE ) , 1.5707963267948965 ); 
+teste( "Math.atan2 ( Number.POSITIVE_INFINITY, Number.MAX_VALUE ) ",
+      Math.atan2 ( Number.POSITIVE_INFINITY, Number.MAX_VALUE ) , 1.5707963267948965 );
 
 
-teste( "Math.atan2 ( Number.POSITIVE_INFINITY, Number.MIN_VALUE ) ", 
-      Math.atan2 ( Number.POSITIVE_INFINITY, Number.MIN_VALUE ) , 1.5707963267948965 ); 
+teste( "Math.atan2 ( Number.POSITIVE_INFINITY, Number.MIN_VALUE ) ",
+      Math.atan2 ( Number.POSITIVE_INFINITY, Number.MIN_VALUE ) , 1.5707963267948965 );
 
 
-teste( "Math.atan2 ( Number.POSITIVE_INFINITY, Number.NaN ) ", 
-      Math.atan2 ( Number.POSITIVE_INFINITY, Number.NaN ) , Number.NaN ); 
+teste( "Math.atan2 ( Number.POSITIVE_INFINITY, Number.NaN ) ",
+      Math.atan2 ( Number.POSITIVE_INFINITY, Number.NaN ) , Number.NaN );
 
 
-teste( "Math.atan2 ( Number.POSITIVE_INFINITY, 0 ) ", Math.atan2 ( Number.POSITIVE_INFINITY, 0 ) , 1.5707963267948965 ); 
+teste( "Math.atan2 ( Number.POSITIVE_INFINITY, 0 ) ", Math.atan2 ( Number.POSITIVE_INFINITY, 0 ) , 1.5707963267948965 );
 
 
-teste( "Math.atan2 ( Number.POSITIVE_INFINITY, -0 ) ", Math.atan2 ( Number.POSITIVE_INFINITY, -0 ) , 1.5707963267948965 ); 
+teste( "Math.atan2 ( Number.POSITIVE_INFINITY, -0 ) ", Math.atan2 ( Number.POSITIVE_INFINITY, -0 ) , 1.5707963267948965 );
 
 
-teste( "Math.atan2 ( Number.POSITIVE_INFINITY, 1 ) ", Math.atan2 ( Number.POSITIVE_INFINITY, 1 ) , 1.5707963267948965 ); 
+teste( "Math.atan2 ( Number.POSITIVE_INFINITY, 1 ) ", Math.atan2 ( Number.POSITIVE_INFINITY, 1 ) , 1.5707963267948965 );
 
 
-teste( "Math.atan2 ( Number.POSITIVE_INFINITY, 1.012 ) ", 
-      Math.atan2 ( Number.POSITIVE_INFINITY, 1.012 ) , 1.5707963267948965 ); 
+teste( "Math.atan2 ( Number.POSITIVE_INFINITY, 1.012 ) ",
+      Math.atan2 ( Number.POSITIVE_INFINITY, 1.012 ) , 1.5707963267948965 );
 
 
-teste( "Math.atan2 ( Number.POSITIVE_INFINITY, -1.12 ) ", 
-      Math.atan2 ( Number.POSITIVE_INFINITY, -1.12 ) , 1.5707963267948965 ); 
+teste( "Math.atan2 ( Number.POSITIVE_INFINITY, -1.12 ) ",
+      Math.atan2 ( Number.POSITIVE_INFINITY, -1.12 ) , 1.5707963267948965 );
 
 
-teste( "Math.atan2 ( Number.POSITIVE_INFINITY, 0.499 ) ", 
-      Math.atan2 ( Number.POSITIVE_INFINITY, 0.499 ) , 1.5707963267948965 ); 
+teste( "Math.atan2 ( Number.POSITIVE_INFINITY, 0.499 ) ",
+      Math.atan2 ( Number.POSITIVE_INFINITY, 0.499 ) , 1.5707963267948965 );
 
 
-teste( "Math.atan2 ( Number.POSITIVE_INFINITY, -0.5 ) ", Math.atan2 ( Number.POSITIVE_INFINITY, -0.5 ) , 1.5707963267948965 ); 
+teste( "Math.atan2 ( Number.POSITIVE_INFINITY, -0.5 ) ", Math.atan2 ( Number.POSITIVE_INFINITY, -0.5 ) , 1.5707963267948965 );
 
 
-teste( "Math.atan2 ( Number.NEGATIVE_INFINITY, Number.POSITIVE_INFINITY ) ", 
-      Math.atan2 ( Number.NEGATIVE_INFINITY, Number.POSITIVE_INFINITY ) , -0.7853981633974483 ); 
+teste( "Math.atan2 ( Number.NEGATIVE_INFINITY, Number.POSITIVE_INFINITY ) ",
+      Math.atan2 ( Number.NEGATIVE_INFINITY, Number.POSITIVE_INFINITY ) , -0.7853981633974483 );
 /* ECMA: If y is -Infinity and x is +Infinity, the result is an implementation-dependent approximation to -PI/4. */
 
 
-teste( "Math.atan2 ( Number.NEGATIVE_INFINITY, Number.NEGATIVE_INFINITY ) ", 
-      Math.atan2 ( Number.NEGATIVE_INFINITY, Number.NEGATIVE_INFINITY ) , -2.356194490192345 ); 
+teste( "Math.atan2 ( Number.NEGATIVE_INFINITY, Number.NEGATIVE_INFINITY ) ",
+      Math.atan2 ( Number.NEGATIVE_INFINITY, Number.NEGATIVE_INFINITY ) , -2.356194490192345 );
 /* ECMA: If y is -Infinity and x is -Infinity, the result is an implementation-dependent approximation to -3 PI/4. */
 
 
-teste( "Math.atan2 ( Number.NEGATIVE_INFINITY, Number.MAX_VALUE ) ", 
-      Math.atan2 ( Number.NEGATIVE_INFINITY, Number.MAX_VALUE ) , -1.5707963267948965 ); 
+teste( "Math.atan2 ( Number.NEGATIVE_INFINITY, Number.MAX_VALUE ) ",
+      Math.atan2 ( Number.NEGATIVE_INFINITY, Number.MAX_VALUE ) , -1.5707963267948965 );
 
 
-teste( "Math.atan2 ( Number.NEGATIVE_INFINITY, Number.MIN_VALUE ) ", 
-      Math.atan2 ( Number.NEGATIVE_INFINITY, Number.MIN_VALUE ) , -1.5707963267948965 ); 
+teste( "Math.atan2 ( Number.NEGATIVE_INFINITY, Number.MIN_VALUE ) ",
+      Math.atan2 ( Number.NEGATIVE_INFINITY, Number.MIN_VALUE ) , -1.5707963267948965 );
 
 
-test( "Math.atan2 ( Number.NEGATIVE_INFINITY, Number.NaN ) ", 
-      Math.atan2 ( Number.NEGATIVE_INFINITY, Number.NaN ) , Number.NaN ); 
+test( "Math.atan2 ( Number.NEGATIVE_INFINITY, Number.NaN ) ",
+      Math.atan2 ( Number.NEGATIVE_INFINITY, Number.NaN ) , Number.NaN );
 
 
-teste( "Math.atan2 ( Number.NEGATIVE_INFINITY, 0 ) ", Math.atan2 ( Number.NEGATIVE_INFINITY, 0 ) , -1.5707963267948965 ); 
+teste( "Math.atan2 ( Number.NEGATIVE_INFINITY, 0 ) ", Math.atan2 ( Number.NEGATIVE_INFINITY, 0 ) , -1.5707963267948965 );
 
 
-teste( "Math.atan2 ( Number.NEGATIVE_INFINITY, -0 ) ", Math.atan2 ( Number.NEGATIVE_INFINITY, -0 ) , -1.5707963267948965 ); 
+teste( "Math.atan2 ( Number.NEGATIVE_INFINITY, -0 ) ", Math.atan2 ( Number.NEGATIVE_INFINITY, -0 ) , -1.5707963267948965 );
 
 
-teste( "Math.atan2 ( Number.NEGATIVE_INFINITY, 1 ) ", Math.atan2 ( Number.NEGATIVE_INFINITY, 1 ) , -1.5707963267948965 ); 
+teste( "Math.atan2 ( Number.NEGATIVE_INFINITY, 1 ) ", Math.atan2 ( Number.NEGATIVE_INFINITY, 1 ) , -1.5707963267948965 );
 
 
-teste( "Math.atan2 ( Number.NEGATIVE_INFINITY, 1.012 ) ", 
-      Math.atan2 ( Number.NEGATIVE_INFINITY, 1.012 ) , -1.5707963267948965 ); 
+teste( "Math.atan2 ( Number.NEGATIVE_INFINITY, 1.012 ) ",
+      Math.atan2 ( Number.NEGATIVE_INFINITY, 1.012 ) , -1.5707963267948965 );
 
 
-teste( "Math.atan2 ( Number.NEGATIVE_INFINITY, -1.12 ) ", 
-      Math.atan2 ( Number.NEGATIVE_INFINITY, -1.12 ) , -1.5707963267948965 ); 
+teste( "Math.atan2 ( Number.NEGATIVE_INFINITY, -1.12 ) ",
+      Math.atan2 ( Number.NEGATIVE_INFINITY, -1.12 ) , -1.5707963267948965 );
 
 
-teste( "Math.atan2 ( Number.NEGATIVE_INFINITY, 0.499 ) ", 
-      Math.atan2 ( Number.NEGATIVE_INFINITY, 0.499 ) , -1.5707963267948965 ); 
+teste( "Math.atan2 ( Number.NEGATIVE_INFINITY, 0.499 ) ",
+      Math.atan2 ( Number.NEGATIVE_INFINITY, 0.499 ) , -1.5707963267948965 );
 
 
-teste( "Math.atan2 ( Number.NEGATIVE_INFINITY, -0.5 ) ", Math.atan2 ( Number.NEGATIVE_INFINITY, -0.5 ) , -1.5707963267948965 ); 
+teste( "Math.atan2 ( Number.NEGATIVE_INFINITY, -0.5 ) ", Math.atan2 ( Number.NEGATIVE_INFINITY, -0.5 ) , -1.5707963267948965 );
 
 
-test( "Math.atan2 ( Number.MAX_VALUE, Number.POSITIVE_INFINITY ) ", Math.atan2 ( Number.MAX_VALUE, Number.POSITIVE_INFINITY ) , 0 ); 
+test( "Math.atan2 ( Number.MAX_VALUE, Number.POSITIVE_INFINITY ) ", Math.atan2 ( Number.MAX_VALUE, Number.POSITIVE_INFINITY ) , 0 );
 
 
-teste( "Math.atan2 ( Number.MAX_VALUE, Number.NEGATIVE_INFINITY ) ", Math.atan2 ( Number.MAX_VALUE, Number.NEGATIVE_INFINITY ) , Math.PI ); 
+teste( "Math.atan2 ( Number.MAX_VALUE, Number.NEGATIVE_INFINITY ) ", Math.atan2 ( Number.MAX_VALUE, Number.NEGATIVE_INFINITY ) , Math.PI );
 
 
-teste( "Math.atan2 ( Number.MAX_VALUE, Number.MAX_VALUE ) ", Math.atan2 ( Number.MAX_VALUE, Number.MAX_VALUE ) , 0.7853981633974483 ); 
+teste( "Math.atan2 ( Number.MAX_VALUE, Number.MAX_VALUE ) ", Math.atan2 ( Number.MAX_VALUE, Number.MAX_VALUE ) , 0.7853981633974483 );
 
 
-teste( "Math.atan2 ( Number.MAX_VALUE, Number.MIN_VALUE ) ", Math.atan2 ( Number.MAX_VALUE, Number.MIN_VALUE ) , 1.5707963267948965 ); 
+teste( "Math.atan2 ( Number.MAX_VALUE, Number.MIN_VALUE ) ", Math.atan2 ( Number.MAX_VALUE, Number.MIN_VALUE ) , 1.5707963267948965 );
 
 
-test( "Math.atan2 ( Number.MAX_VALUE, Number.NaN ) ", Math.atan2 ( Number.MAX_VALUE, Number.NaN ) , Number.NaN ); 
+test( "Math.atan2 ( Number.MAX_VALUE, Number.NaN ) ", Math.atan2 ( Number.MAX_VALUE, Number.NaN ) , Number.NaN );
 
 
-teste( "Math.atan2 ( Number.MAX_VALUE, 0 ) ", Math.atan2 ( Number.MAX_VALUE, 0 ) , 1.5707963267948965 ); 
+teste( "Math.atan2 ( Number.MAX_VALUE, 0 ) ", Math.atan2 ( Number.MAX_VALUE, 0 ) , 1.5707963267948965 );
 
 
-teste( "Math.atan2 ( Number.MAX_VALUE, -0 ) ", Math.atan2 ( Number.MAX_VALUE, -0 ) , 1.5707963267948965 ); 
+teste( "Math.atan2 ( Number.MAX_VALUE, -0 ) ", Math.atan2 ( Number.MAX_VALUE, -0 ) , 1.5707963267948965 );
 
 
-teste( "Math.atan2 ( Number.MAX_VALUE, 1 ) ", Math.atan2 ( Number.MAX_VALUE, 1 ) , 1.5707963267948965 ); 
+teste( "Math.atan2 ( Number.MAX_VALUE, 1 ) ", Math.atan2 ( Number.MAX_VALUE, 1 ) , 1.5707963267948965 );
 
 
-teste( "Math.atan2 ( Number.MAX_VALUE, 1.012 ) ", Math.atan2 ( Number.MAX_VALUE, 1.012 ) , 1.5707963267948965 ); 
+teste( "Math.atan2 ( Number.MAX_VALUE, 1.012 ) ", Math.atan2 ( Number.MAX_VALUE, 1.012 ) , 1.5707963267948965 );
 
 
-teste( "Math.atan2 ( Number.MAX_VALUE, -1.12 ) ", Math.atan2 ( Number.MAX_VALUE, -1.12 ) , 1.5707963267948965 ); 
+teste( "Math.atan2 ( Number.MAX_VALUE, -1.12 ) ", Math.atan2 ( Number.MAX_VALUE, -1.12 ) , 1.5707963267948965 );
 
 
-teste( "Math.atan2 ( Number.MAX_VALUE, 0.499 ) ", Math.atan2 ( Number.MAX_VALUE, 0.499 ) , 1.5707963267948965 ); 
+teste( "Math.atan2 ( Number.MAX_VALUE, 0.499 ) ", Math.atan2 ( Number.MAX_VALUE, 0.499 ) , 1.5707963267948965 );
 
 
-teste( "Math.atan2 ( Number.MAX_VALUE, -0.5 ) ", Math.atan2 ( Number.MAX_VALUE, -0.5 ) , 1.5707963267948965 ); 
+teste( "Math.atan2 ( Number.MAX_VALUE, -0.5 ) ", Math.atan2 ( Number.MAX_VALUE, -0.5 ) , 1.5707963267948965 );
 
 
-test( "Math.atan2 ( Number.MIN_VALUE, Number.POSITIVE_INFINITY ) ", Math.atan2 ( Number.MIN_VALUE, Number.POSITIVE_INFINITY ) , 0 ); 
+test( "Math.atan2 ( Number.MIN_VALUE, Number.POSITIVE_INFINITY ) ", Math.atan2 ( Number.MIN_VALUE, Number.POSITIVE_INFINITY ) , 0 );
 
 
-teste( "Math.atan2 ( Number.MIN_VALUE, Number.NEGATIVE_INFINITY ) ", Math.atan2 ( Number.MIN_VALUE, Number.NEGATIVE_INFINITY ) , Math.PI ); 
+teste( "Math.atan2 ( Number.MIN_VALUE, Number.NEGATIVE_INFINITY ) ", Math.atan2 ( Number.MIN_VALUE, Number.NEGATIVE_INFINITY ) , Math.PI );
 
 
-teste( "Math.atan2 ( Number.MIN_VALUE, Number.MAX_VALUE ) ", Math.atan2 ( Number.MIN_VALUE, Number.MAX_VALUE ) , 0 ); 
+teste( "Math.atan2 ( Number.MIN_VALUE, Number.MAX_VALUE ) ", Math.atan2 ( Number.MIN_VALUE, Number.MAX_VALUE ) , 0 );
 
 
-teste( "Math.atan2 ( Number.MIN_VALUE, Number.MIN_VALUE ) ", Math.atan2 ( Number.MIN_VALUE, Number.MIN_VALUE ) , Math.PI/4 ); 
+teste( "Math.atan2 ( Number.MIN_VALUE, Number.MIN_VALUE ) ", Math.atan2 ( Number.MIN_VALUE, Number.MIN_VALUE ) , Math.PI/4 );
 
 
-test( "Math.atan2 ( Number.MIN_VALUE, Number.NaN ) ", Math.atan2 ( Number.MIN_VALUE, Number.NaN ) , Number.NaN ); 
+test( "Math.atan2 ( Number.MIN_VALUE, Number.NaN ) ", Math.atan2 ( Number.MIN_VALUE, Number.NaN ) , Number.NaN );
 
 
-teste( "Math.atan2 ( Number.MIN_VALUE, 0 ) ", Math.atan2 ( Number.MIN_VALUE, 0 ) , Math.PI/2 ); 
+teste( "Math.atan2 ( Number.MIN_VALUE, 0 ) ", Math.atan2 ( Number.MIN_VALUE, 0 ) , Math.PI/2 );
 
 
-teste( "Math.atan2 ( Number.MIN_VALUE, -0 ) ", Math.atan2 ( Number.MIN_VALUE, -0 ) , Math.PI/2 ); 
+teste( "Math.atan2 ( Number.MIN_VALUE, -0 ) ", Math.atan2 ( Number.MIN_VALUE, -0 ) , Math.PI/2 );
 
 
-teste( "Math.atan2 ( Number.MIN_VALUE, 1 ) ", Math.atan2 ( Number.MIN_VALUE, 1 ) , Math.tan ( Number.MIN_VALUE ) ); 
+teste( "Math.atan2 ( Number.MIN_VALUE, 1 ) ", Math.atan2 ( Number.MIN_VALUE, 1 ) , Math.tan ( Number.MIN_VALUE ) );
 
 
 /* Basically, there are two right answers here: MIN_VALUE and 0.  */
-test( "Math.atan2 ( Number.MIN_VALUE, 1.012 ) ", 
+test( "Math.atan2 ( Number.MIN_VALUE, 1.012 ) ",
       epsclose(Math.atan2( Number.MIN_VALUE, 1.012 ),Number.MIN_VALUE) || 0==Math.atan2( Number.MIN_VALUE, 1.012 ),
-      true ); 
+      true );
 
 
-teste( "Math.atan2 ( Number.MIN_VALUE, -1.12 ) ", Math.atan2 ( Number.MIN_VALUE, -1.12 ) , Math.PI ); 
+teste( "Math.atan2 ( Number.MIN_VALUE, -1.12 ) ", Math.atan2 ( Number.MIN_VALUE, -1.12 ) , Math.PI );
 
 
-teste( "Math.atan2 ( Number.MIN_VALUE, 0.499 ) ", Math.atan2 ( Number.MIN_VALUE, 0.499 ) , 1e-323 ); 
+teste( "Math.atan2 ( Number.MIN_VALUE, 0.499 ) ", Math.atan2 ( Number.MIN_VALUE, 0.499 ) , 1e-323 );
 
 
-teste( "Math.atan2 ( Number.MIN_VALUE, -0.5 ) ", Math.atan2 ( Number.MIN_VALUE, -0.5 ) , Math.PI ); 
+teste( "Math.atan2 ( Number.MIN_VALUE, -0.5 ) ", Math.atan2 ( Number.MIN_VALUE, -0.5 ) , Math.PI );
 
 
-test( "Math.atan2 ( Number.NaN, Number.POSITIVE_INFINITY ) ", Math.atan2 ( Number.NaN, Number.POSITIVE_INFINITY ) , Number.NaN ); 
+test( "Math.atan2 ( Number.NaN, Number.POSITIVE_INFINITY ) ", Math.atan2 ( Number.NaN, Number.POSITIVE_INFINITY ) , Number.NaN );
 
 
-test( "Math.atan2 ( Number.NaN, Number.NEGATIVE_INFINITY ) ", Math.atan2 ( Number.NaN, Number.NEGATIVE_INFINITY ) , Number.NaN ); 
+test( "Math.atan2 ( Number.NaN, Number.NEGATIVE_INFINITY ) ", Math.atan2 ( Number.NaN, Number.NEGATIVE_INFINITY ) , Number.NaN );
 
 
-test( "Math.atan2 ( Number.NaN, Number.MAX_VALUE ) ", Math.atan2 ( Number.NaN, Number.MAX_VALUE ) , Number.NaN ); 
+test( "Math.atan2 ( Number.NaN, Number.MAX_VALUE ) ", Math.atan2 ( Number.NaN, Number.MAX_VALUE ) , Number.NaN );
 
 
-test( "Math.atan2 ( Number.NaN, Number.MIN_VALUE ) ", Math.atan2 ( Number.NaN, Number.MIN_VALUE ) , Number.NaN ); 
+test( "Math.atan2 ( Number.NaN, Number.MIN_VALUE ) ", Math.atan2 ( Number.NaN, Number.MIN_VALUE ) , Number.NaN );
 
 
-test( "Math.atan2 ( Number.NaN, Number.NaN ) ", Math.atan2 ( Number.NaN, Number.NaN ) , Number.NaN ); 
+test( "Math.atan2 ( Number.NaN, Number.NaN ) ", Math.atan2 ( Number.NaN, Number.NaN ) , Number.NaN );
 
 
-test( "Math.atan2 ( Number.NaN, 0 ) ", Math.atan2 ( Number.NaN, 0 ) , Number.NaN ); 
+test( "Math.atan2 ( Number.NaN, 0 ) ", Math.atan2 ( Number.NaN, 0 ) , Number.NaN );
 
 
-test( "Math.atan2 ( Number.NaN, -0 ) ", Math.atan2 ( Number.NaN, -0 ) , Number.NaN ); 
+test( "Math.atan2 ( Number.NaN, -0 ) ", Math.atan2 ( Number.NaN, -0 ) , Number.NaN );
 
 
-test( "Math.atan2 ( Number.NaN, 1 ) ", Math.atan2 ( Number.NaN, 1 ) , Number.NaN ); 
+test( "Math.atan2 ( Number.NaN, 1 ) ", Math.atan2 ( Number.NaN, 1 ) , Number.NaN );
 
 
-test( "Math.atan2 ( Number.NaN, 1.012 ) ", Math.atan2 ( Number.NaN, 1.012 ) , Number.NaN ); 
+test( "Math.atan2 ( Number.NaN, 1.012 ) ", Math.atan2 ( Number.NaN, 1.012 ) , Number.NaN );
 
 
-test( "Math.atan2 ( Number.NaN, -1.12 ) ", Math.atan2 ( Number.NaN, -1.12 ) , Number.NaN ); 
+test( "Math.atan2 ( Number.NaN, -1.12 ) ", Math.atan2 ( Number.NaN, -1.12 ) , Number.NaN );
 
 
-test( "Math.atan2 ( Number.NaN, 0.499 ) ", Math.atan2 ( Number.NaN, 0.499 ) , Number.NaN ); 
+test( "Math.atan2 ( Number.NaN, 0.499 ) ", Math.atan2 ( Number.NaN, 0.499 ) , Number.NaN );
 
 
-test( "Math.atan2 ( Number.NaN, -0.5 ) ", Math.atan2 ( Number.NaN, -0.5 ) , Number.NaN ); 
+test( "Math.atan2 ( Number.NaN, -0.5 ) ", Math.atan2 ( Number.NaN, -0.5 ) , Number.NaN );
 
 
-teste( "Math.atan2 ( 0, Number.POSITIVE_INFINITY ) ", Math.atan2 ( 0, Number.POSITIVE_INFINITY ) , 0 ); 
+teste( "Math.atan2 ( 0, Number.POSITIVE_INFINITY ) ", Math.atan2 ( 0, Number.POSITIVE_INFINITY ) , 0 );
 
 
-teste( "Math.atan2 ( 0, Number.NEGATIVE_INFINITY ) ", Math.atan2 ( 0, Number.NEGATIVE_INFINITY ) , Math.PI ); 
+teste( "Math.atan2 ( 0, Number.NEGATIVE_INFINITY ) ", Math.atan2 ( 0, Number.NEGATIVE_INFINITY ) , Math.PI );
 
 
-teste( "Math.atan2 ( 0, Number.MAX_VALUE ) ", Math.atan2 ( 0, Number.MAX_VALUE ) , 0 ); 
+teste( "Math.atan2 ( 0, Number.MAX_VALUE ) ", Math.atan2 ( 0, Number.MAX_VALUE ) , 0 );
 
 
-teste( "Math.atan2 ( 0, Number.MIN_VALUE ) ", Math.atan2 ( 0, Number.MIN_VALUE ) , 0 ); 
+teste( "Math.atan2 ( 0, Number.MIN_VALUE ) ", Math.atan2 ( 0, Number.MIN_VALUE ) , 0 );
 
 
-test( "Math.atan2 ( 0, Number.NaN ) ", Math.atan2 ( 0, Number.NaN ) , Number.NaN ); 
+test( "Math.atan2 ( 0, Number.NaN ) ", Math.atan2 ( 0, Number.NaN ) , Number.NaN );
 
 
-test( "Math.atan2 ( 0, 0 ) ", Math.atan2 ( 0, 0 ) , 0 ); 
+test( "Math.atan2 ( 0, 0 ) ", Math.atan2 ( 0, 0 ) , 0 );
 
 
-teste( "Math.atan2 ( 0, -0 ) ", Math.atan2 ( 0, -0 ) , Math.PI ); 
+teste( "Math.atan2 ( 0, -0 ) ", Math.atan2 ( 0, -0 ) , Math.PI );
 
 
-teste( "Math.atan2 ( 0, 1 ) ", Math.atan2 ( 0, 1 ) , 0 ); 
+teste( "Math.atan2 ( 0, 1 ) ", Math.atan2 ( 0, 1 ) , 0 );
 
 
-teste( "Math.atan2 ( 0, 1.012 ) ", Math.atan2 ( 0, 1.012 ) , 0 ); 
+teste( "Math.atan2 ( 0, 1.012 ) ", Math.atan2 ( 0, 1.012 ) , 0 );
 
 
-teste( "Math.atan2 ( 0, -1.12 ) ", Math.atan2 ( 0, -1.12 ) , Math.PI ); 
+teste( "Math.atan2 ( 0, -1.12 ) ", Math.atan2 ( 0, -1.12 ) , Math.PI );
 
 
-teste( "Math.atan2 ( 0, 0.499 ) ", Math.atan2 ( 0, 0.499 ) , 0 ); 
+teste( "Math.atan2 ( 0, 0.499 ) ", Math.atan2 ( 0, 0.499 ) , 0 );
 
 
-teste( "Math.atan2 ( 0, -0.5 ) ", Math.atan2 ( 0, -0.5 ) , Math.PI ); 
+teste( "Math.atan2 ( 0, -0.5 ) ", Math.atan2 ( 0, -0.5 ) , Math.PI );
 
 
-teste( "Math.atan2 ( -0, Number.POSITIVE_INFINITY ) ", Math.atan2 ( -0, Number.POSITIVE_INFINITY ) , 0 ); 
+teste( "Math.atan2 ( -0, Number.POSITIVE_INFINITY ) ", Math.atan2 ( -0, Number.POSITIVE_INFINITY ) , 0 );
 
 
-teste( "Math.atan2 ( -0, Number.NEGATIVE_INFINITY ) ", Math.atan2 ( -0, Number.NEGATIVE_INFINITY ) , -Math.PI ); 
+teste( "Math.atan2 ( -0, Number.NEGATIVE_INFINITY ) ", Math.atan2 ( -0, Number.NEGATIVE_INFINITY ) , -Math.PI );
 
 
-teste( "Math.atan2 ( -0, Number.MAX_VALUE ) ", Math.atan2 ( -0, Number.MAX_VALUE ) , 0 ); 
+teste( "Math.atan2 ( -0, Number.MAX_VALUE ) ", Math.atan2 ( -0, Number.MAX_VALUE ) , 0 );
 
 
-teste( "Math.atan2 ( -0, Number.MIN_VALUE ) ", Math.atan2 ( -0, Number.MIN_VALUE ) , 0 ); 
+teste( "Math.atan2 ( -0, Number.MIN_VALUE ) ", Math.atan2 ( -0, Number.MIN_VALUE ) , 0 );
 
 
-test( "Math.atan2 ( -0, Number.NaN ) ", Math.atan2 ( -0, Number.NaN ) , Number.NaN ); 
+test( "Math.atan2 ( -0, Number.NaN ) ", Math.atan2 ( -0, Number.NaN ) , Number.NaN );
 
 
-teste( "Math.atan2 ( -0, 0 ) ", Math.atan2 ( -0, 0 ) , 0 ); 
+teste( "Math.atan2 ( -0, 0 ) ", Math.atan2 ( -0, 0 ) , 0 );
 
 
-teste( "Math.atan2 ( -0, -0 ) ", Math.atan2 ( -0, -0 ) , -Math.PI ); 
+teste( "Math.atan2 ( -0, -0 ) ", Math.atan2 ( -0, -0 ) , -Math.PI );
 
 
-teste( "Math.atan2 ( -0, 1 ) ", Math.atan2 ( -0, 1 ) , 0 ); 
+teste( "Math.atan2 ( -0, 1 ) ", Math.atan2 ( -0, 1 ) , 0 );
 
 
-teste( "Math.atan2 ( -0, 1.012 ) ", Math.atan2 ( -0, 1.012 ) , 0 ); 
+teste( "Math.atan2 ( -0, 1.012 ) ", Math.atan2 ( -0, 1.012 ) , 0 );
 
 
-teste( "Math.atan2 ( -0, -1.12 ) ", Math.atan2 ( -0, -1.12 ) , -Math.PI ); 
+teste( "Math.atan2 ( -0, -1.12 ) ", Math.atan2 ( -0, -1.12 ) , -Math.PI );
 
 
-teste( "Math.atan2 ( -0, 0.499 ) ", Math.atan2 ( -0, 0.499 ) , 0 ); 
+teste( "Math.atan2 ( -0, 0.499 ) ", Math.atan2 ( -0, 0.499 ) , 0 );
 
 
-teste( "Math.atan2 ( -0, -0.5 ) ", Math.atan2 ( -0, -0.5 ) , -Math.PI ); 
+teste( "Math.atan2 ( -0, -0.5 ) ", Math.atan2 ( -0, -0.5 ) , -Math.PI );
 
 
-teste( "Math.atan2 ( 1, Number.POSITIVE_INFINITY ) ", Math.atan2 ( 1, Number.POSITIVE_INFINITY ) , 0 ); 
+teste( "Math.atan2 ( 1, Number.POSITIVE_INFINITY ) ", Math.atan2 ( 1, Number.POSITIVE_INFINITY ) , 0 );
 
 
-teste( "Math.atan2 ( 1, Number.NEGATIVE_INFINITY ) ", Math.atan2 ( 1, Number.NEGATIVE_INFINITY ) , Math.PI ); 
+teste( "Math.atan2 ( 1, Number.NEGATIVE_INFINITY ) ", Math.atan2 ( 1, Number.NEGATIVE_INFINITY ) , Math.PI );
 
 
-teste( "Math.atan2 ( 1, Number.MAX_VALUE ) ", Math.atan2 ( 1, Number.MAX_VALUE ) , 5.562684646268003e-309 ); 
+teste( "Math.atan2 ( 1, Number.MAX_VALUE ) ", Math.atan2 ( 1, Number.MAX_VALUE ) , 5.562684646268003e-309 );
 
 
-teste( "Math.atan2 ( 1, Number.MIN_VALUE ) ", Math.atan2 ( 1, Number.MIN_VALUE ) , Math.PI/2 ); 
+teste( "Math.atan2 ( 1, Number.MIN_VALUE ) ", Math.atan2 ( 1, Number.MIN_VALUE ) , Math.PI/2 );
 
 
-test( "Math.atan2 ( 1, Number.NaN ) ", Math.atan2 ( 1, Number.NaN ) , Number.NaN ); 
+test( "Math.atan2 ( 1, Number.NaN ) ", Math.atan2 ( 1, Number.NaN ) , Number.NaN );
 
 
-teste( "Math.atan2 ( 1, 0 ) ", Math.atan2 ( 1, 0 ) , Math.PI/2 ); 
+teste( "Math.atan2 ( 1, 0 ) ", Math.atan2 ( 1, 0 ) , Math.PI/2 );
 
 
-teste( "Math.atan2 ( 1, -0 ) ", Math.atan2 ( 1, -0 ) , Math.PI/2 ); 
+teste( "Math.atan2 ( 1, -0 ) ", Math.atan2 ( 1, -0 ) , Math.PI/2 );
 
 
-teste( "Math.atan2 ( 1, 1 ) ", Math.atan2 ( 1, 1 ) , Math.PI/4 ); 
+teste( "Math.atan2 ( 1, 1 ) ", Math.atan2 ( 1, 1 ) , Math.PI/4 );
 
 
-teste( "Math.atan2 ( 1, 1.012 ) ", Math.atan2 ( 1, 1.012 ) , 0.7794340194036072 ); 
+teste( "Math.atan2 ( 1, 1.012 ) ", Math.atan2 ( 1, 1.012 ) , 0.7794340194036072 );
 
 
-teste( "Math.atan2 ( 1, -1.12 ) ", Math.atan2 ( 1, -1.12 ) , 2.4127379271371625 ); 
+teste( "Math.atan2 ( 1, -1.12 ) ", Math.atan2 ( 1, -1.12 ) , 2.4127379271371625 );
 
 
-teste( "Math.atan2 ( 1, 0.499 ) ", Math.atan2 ( 1, 0.499 ) , 1.1079490377512701 ); 
+teste( "Math.atan2 ( 1, 0.499 ) ", Math.atan2 ( 1, 0.499 ) , 1.1079490377512701 );
 
 
-teste( "Math.atan2 ( 1, -0.5 ) ", Math.atan2 ( 1, -0.5 ) , 2.0344439357957027 ); 
+teste( "Math.atan2 ( 1, -0.5 ) ", Math.atan2 ( 1, -0.5 ) , 2.0344439357957027 );
 
 
-teste( "Math.atan2 ( 1.012, Number.POSITIVE_INFINITY ) ", Math.atan2 ( 1.012, Number.POSITIVE_INFINITY ) , 0 ); 
+teste( "Math.atan2 ( 1.012, Number.POSITIVE_INFINITY ) ", Math.atan2 ( 1.012, Number.POSITIVE_INFINITY ) , 0 );
 
 
-teste( "Math.atan2 ( 1.012, Number.NEGATIVE_INFINITY ) ", Math.atan2 ( 1.012, Number.NEGATIVE_INFINITY ) , Math.PI ); 
+teste( "Math.atan2 ( 1.012, Number.NEGATIVE_INFINITY ) ", Math.atan2 ( 1.012, Number.NEGATIVE_INFINITY ) , Math.PI );
 
 
-teste( "Math.atan2 ( 1.012, Number.MAX_VALUE ) ", Math.atan2 ( 1.012, Number.MAX_VALUE ) , 5.629436862023217e-309 ); 
+teste( "Math.atan2 ( 1.012, Number.MAX_VALUE ) ", Math.atan2 ( 1.012, Number.MAX_VALUE ) , 5.629436862023217e-309 );
 
 
-teste( "Math.atan2 ( 1.012, Number.MIN_VALUE ) ", Math.atan2 ( 1.012, Number.MIN_VALUE ) , 1.5707963267948965 ); 
+teste( "Math.atan2 ( 1.012, Number.MIN_VALUE ) ", Math.atan2 ( 1.012, Number.MIN_VALUE ) , 1.5707963267948965 );
 
 
-test( "Math.atan2 ( 1.012, Number.NaN ) ", Math.atan2 ( 1.012, Number.NaN ) , Number.NaN ); 
+test( "Math.atan2 ( 1.012, Number.NaN ) ", Math.atan2 ( 1.012, Number.NaN ) , Number.NaN );
 
 
-teste( "Math.atan2 ( 1.012, 0 ) ", Math.atan2 ( 1.012, 0 ) , 1.5707963267948965 ); 
+teste( "Math.atan2 ( 1.012, 0 ) ", Math.atan2 ( 1.012, 0 ) , 1.5707963267948965 );
 
 
-teste( "Math.atan2 ( 1.012, -0 ) ", Math.atan2 ( 1.012, -0 ) , 1.5707963267948965 ); 
+teste( "Math.atan2 ( 1.012, -0 ) ", Math.atan2 ( 1.012, -0 ) , 1.5707963267948965 );
 
 
-teste( "Math.atan2 ( 1.012, 1 ) ", Math.atan2 ( 1.012, 1 ) , 0.7913623073912894 ); 
+teste( "Math.atan2 ( 1.012, 1 ) ", Math.atan2 ( 1.012, 1 ) , 0.7913623073912894 );
 
 
-teste( "Math.atan2 ( 1.012, 1.012 ) ", Math.atan2 ( 1.012, 1.012 ) , 0.7853981633974483 ); 
+teste( "Math.atan2 ( 1.012, 1.012 ) ", Math.atan2 ( 1.012, 1.012 ) , 0.7853981633974483 );
 
 
-teste( "Math.atan2 ( 1.012, -1.12 ) ", Math.atan2 ( 1.012, -1.12 ) , 2.406807887224191 ); 
+teste( "Math.atan2 ( 1.012, -1.12 ) ", Math.atan2 ( 1.012, -1.12 ) , 2.406807887224191 );
 
 
-teste( "Math.atan2 ( 1.012, 0.499 ) ", Math.atan2 ( 1.012, 0.499 ) , 1.112697610505964 ); 
+teste( "Math.atan2 ( 1.012, 0.499 ) ", Math.atan2 ( 1.012, 0.499 ) , 1.112697610505964 );
 
 
-teste( "Math.atan2 ( 1.012, -0.5 ) ", Math.atan2 ( 1.012, -0.5 ) , 2.029689613455948 ); 
+teste( "Math.atan2 ( 1.012, -0.5 ) ", Math.atan2 ( 1.012, -0.5 ) , 2.029689613455948 );
 
 
-teste( "Math.atan2 ( -1.12, Number.POSITIVE_INFINITY ) ", Math.atan2 ( -1.12, Number.POSITIVE_INFINITY ) , 0 ); 
+teste( "Math.atan2 ( -1.12, Number.POSITIVE_INFINITY ) ", Math.atan2 ( -1.12, Number.POSITIVE_INFINITY ) , 0 );
 
 
-teste( "Math.atan2 ( -1.12, Number.NEGATIVE_INFINITY ) ", Math.atan2 ( -1.12, Number.NEGATIVE_INFINITY ) , -Math.PI ); 
+teste( "Math.atan2 ( -1.12, Number.NEGATIVE_INFINITY ) ", Math.atan2 ( -1.12, Number.NEGATIVE_INFINITY ) , -Math.PI );
 
 
-teste( "Math.atan2 ( -1.12, Number.MAX_VALUE ) ", Math.atan2 ( -1.12, Number.MAX_VALUE ) , -6.230206803820164e-309 ); 
+teste( "Math.atan2 ( -1.12, Number.MAX_VALUE ) ", Math.atan2 ( -1.12, Number.MAX_VALUE ) , -6.230206803820164e-309 );
 
 
-teste( "Math.atan2 ( -1.12, Number.MIN_VALUE ) ", Math.atan2 ( -1.12, Number.MIN_VALUE ) , -1.5707963267948965 ); 
+teste( "Math.atan2 ( -1.12, Number.MIN_VALUE ) ", Math.atan2 ( -1.12, Number.MIN_VALUE ) , -1.5707963267948965 );
 
 
-test( "Math.atan2 ( -1.12, Number.NaN ) ", Math.atan2 ( -1.12, Number.NaN ) , Number.NaN ); 
+test( "Math.atan2 ( -1.12, Number.NaN ) ", Math.atan2 ( -1.12, Number.NaN ) , Number.NaN );
 
 
-teste( "Math.atan2 ( -1.12, 0 ) ", Math.atan2 ( -1.12, 0 ) , -1.5707963267948965 ); 
+teste( "Math.atan2 ( -1.12, 0 ) ", Math.atan2 ( -1.12, 0 ) , -1.5707963267948965 );
 
 
-teste( "Math.atan2 ( -1.12, -0 ) ", Math.atan2 ( -1.12, -0 ) , -1.5707963267948965 ); 
+teste( "Math.atan2 ( -1.12, -0 ) ", Math.atan2 ( -1.12, -0 ) , -1.5707963267948965 );
 
 
-teste( "Math.atan2 ( -1.12, 1 ) ", Math.atan2 ( -1.12, 1 ) , -0.8419416003422657 ); 
+teste( "Math.atan2 ( -1.12, 1 ) ", Math.atan2 ( -1.12, 1 ) , -0.8419416003422657 );
 
 
-teste( "Math.atan2 ( -1.12, 1.012 ) ", Math.atan2 ( -1.12, 1.012 ) , -0.8360115604292945 ); 
+teste( "Math.atan2 ( -1.12, 1.012 ) ", Math.atan2 ( -1.12, 1.012 ) , -0.8360115604292945 );
 
 
-teste( "Math.atan2 ( -1.12, -1.12 ) ", Math.atan2 ( -1.12, -1.12 ) , -2.356194490192345 ); 
+teste( "Math.atan2 ( -1.12, -1.12 ) ", Math.atan2 ( -1.12, -1.12 ) , -2.356194490192345 );
 
 
-teste( "Math.atan2 ( -1.12, 0.499 ) ", Math.atan2 ( -1.12, 0.499 ) , -1.151661099819374 ); 
+teste( "Math.atan2 ( -1.12, 0.499 ) ", Math.atan2 ( -1.12, 0.499 ) , -1.151661099819374 );
 
 
-teste( "Math.atan2 ( -1.12, -0.5 ) ", Math.atan2 ( -1.12, -0.5 ) , -1.9906762840004483 ); 
+teste( "Math.atan2 ( -1.12, -0.5 ) ", Math.atan2 ( -1.12, -0.5 ) , -1.9906762840004483 );
 
 
-teste( "Math.atan2 ( 0.499, Number.POSITIVE_INFINITY ) ", Math.atan2 ( 0.499, Number.POSITIVE_INFINITY ) , 0 ); 
+teste( "Math.atan2 ( 0.499, Number.POSITIVE_INFINITY ) ", Math.atan2 ( 0.499, Number.POSITIVE_INFINITY ) , 0 );
 
 
-teste( "Math.atan2 ( 0.499, Number.NEGATIVE_INFINITY ) ", Math.atan2 ( 0.499, Number.NEGATIVE_INFINITY ) , Math.PI ); 
+teste( "Math.atan2 ( 0.499, Number.NEGATIVE_INFINITY ) ", Math.atan2 ( 0.499, Number.NEGATIVE_INFINITY ) , Math.PI );
 
 
-teste( "Math.atan2 ( 0.499, Number.MAX_VALUE ) ", Math.atan2 ( 0.499, Number.MAX_VALUE ) , 2.77577963848773e-309 ); 
+teste( "Math.atan2 ( 0.499, Number.MAX_VALUE ) ", Math.atan2 ( 0.499, Number.MAX_VALUE ) , 2.77577963848773e-309 );
 
 
-teste( "Math.atan2 ( 0.499, Number.MIN_VALUE ) ", Math.atan2 ( 0.499, Number.MIN_VALUE ) , 1.5707963267948965 ); 
+teste( "Math.atan2 ( 0.499, Number.MIN_VALUE ) ", Math.atan2 ( 0.499, Number.MIN_VALUE ) , 1.5707963267948965 );
 
 
-test( "Math.atan2 ( 0.499, Number.NaN ) ", Math.atan2 ( 0.499, Number.NaN ) , Number.NaN ); 
+test( "Math.atan2 ( 0.499, Number.NaN ) ", Math.atan2 ( 0.499, Number.NaN ) , Number.NaN );
 
 
-teste( "Math.atan2 ( 0.499, 0 ) ", Math.atan2 ( 0.499, 0 ) , 1.5707963267948965 ); 
+teste( "Math.atan2 ( 0.499, 0 ) ", Math.atan2 ( 0.499, 0 ) , 1.5707963267948965 );
 
 
-teste( "Math.atan2 ( 0.499, -0 ) ", Math.atan2 ( 0.499, -0 ) , 1.5707963267948965 ); 
+teste( "Math.atan2 ( 0.499, -0 ) ", Math.atan2 ( 0.499, -0 ) , 1.5707963267948965 );
 
 
-teste( "Math.atan2 ( 0.499, 1 ) ", Math.atan2 ( 0.499, 1 ) , 0.4628472890436265 ); 
+teste( "Math.atan2 ( 0.499, 1 ) ", Math.atan2 ( 0.499, 1 ) , 0.4628472890436265 );
 
 
-teste( "Math.atan2 ( 0.499, 1.012 ) ", Math.atan2 ( 0.499, 1.012 ) , 0.4580987162889326 ); 
+teste( "Math.atan2 ( 0.499, 1.012 ) ", Math.atan2 ( 0.499, 1.012 ) , 0.4580987162889326 );
 
 
-teste( "Math.atan2 ( 0.499, -1.12 ) ", Math.atan2 ( 0.499, -1.12 ) , 2.7224574266142705 ); 
+teste( "Math.atan2 ( 0.499, -1.12 ) ", Math.atan2 ( 0.499, -1.12 ) , 2.7224574266142705 );
 
 
-teste( "Math.atan2 ( 0.499, 0.499 ) ", Math.atan2 ( 0.499, 0.499 ) , 0.7853981633974483 ); 
+teste( "Math.atan2 ( 0.499, 0.499 ) ", Math.atan2 ( 0.499, 0.499 ) , 0.7853981633974483 );
 
 
-teste( "Math.atan2 ( 0.499, -0.5 ) ", Math.atan2 ( 0.499, -0.5 ) , 2.3571954908590107 ); 
+teste( "Math.atan2 ( 0.499, -0.5 ) ", Math.atan2 ( 0.499, -0.5 ) , 2.3571954908590107 );
 
 
-teste( "Math.atan2 ( -0.5, Number.POSITIVE_INFINITY ) ", Math.atan2 ( -0.5, Number.POSITIVE_INFINITY ) , 0 ); 
+teste( "Math.atan2 ( -0.5, Number.POSITIVE_INFINITY ) ", Math.atan2 ( -0.5, Number.POSITIVE_INFINITY ) , 0 );
 
 
-teste( "Math.atan2 ( -0.5, Number.NEGATIVE_INFINITY ) ", Math.atan2 ( -0.5, Number.NEGATIVE_INFINITY ) , -Math.PI ); 
+teste( "Math.atan2 ( -0.5, Number.NEGATIVE_INFINITY ) ", Math.atan2 ( -0.5, Number.NEGATIVE_INFINITY ) , -Math.PI );
 
 
-teste( "Math.atan2 ( -0.5, Number.MAX_VALUE ) ", Math.atan2 ( -0.5, Number.MAX_VALUE ) , -2.781342323134e-309 ); 
+teste( "Math.atan2 ( -0.5, Number.MAX_VALUE ) ", Math.atan2 ( -0.5, Number.MAX_VALUE ) , -2.781342323134e-309 );
 
 
-teste( "Math.atan2 ( -0.5, Number.MIN_VALUE ) ", Math.atan2 ( -0.5, Number.MIN_VALUE ) , -1.5707963267948965 ); 
+teste( "Math.atan2 ( -0.5, Number.MIN_VALUE ) ", Math.atan2 ( -0.5, Number.MIN_VALUE ) , -1.5707963267948965 );
 
 
-test( "Math.atan2 ( -0.5, Number.NaN ) ", Math.atan2 ( -0.5, Number.NaN ) , Number.NaN ); 
+test( "Math.atan2 ( -0.5, Number.NaN ) ", Math.atan2 ( -0.5, Number.NaN ) , Number.NaN );
 
 
-teste( "Math.atan2 ( -0.5, 0 ) ", Math.atan2 ( -0.5, 0 ) , -1.5707963267948965 ); 
+teste( "Math.atan2 ( -0.5, 0 ) ", Math.atan2 ( -0.5, 0 ) , -1.5707963267948965 );
 
 
-teste( "Math.atan2 ( -0.5, -0 ) ", Math.atan2 ( -0.5, -0 ) , -1.5707963267948965 ); 
+teste( "Math.atan2 ( -0.5, -0 ) ", Math.atan2 ( -0.5, -0 ) , -1.5707963267948965 );
 
 
-teste( "Math.atan2 ( -0.5, 1 ) ", Math.atan2 ( -0.5, 1 ) , -0.4636476090008061 ); 
+teste( "Math.atan2 ( -0.5, 1 ) ", Math.atan2 ( -0.5, 1 ) , -0.4636476090008061 );
 
 
-teste( "Math.atan2 ( -0.5, 1.012 ) ", Math.atan2 ( -0.5, 1.012 ) , -0.4588932866610517 ); 
+teste( "Math.atan2 ( -0.5, 1.012 ) ", Math.atan2 ( -0.5, 1.012 ) , -0.4588932866610517 );
 
 
-teste( "Math.atan2 ( -0.5, -1.12 ) ", Math.atan2 ( -0.5, -1.12 ) , -2.7217126963842415 ); 
+teste( "Math.atan2 ( -0.5, -1.12 ) ", Math.atan2 ( -0.5, -1.12 ) , -2.7217126963842415 );
 
 
-teste( "Math.atan2 ( -0.5, 0.499 ) ", Math.atan2 ( -0.5, 0.499 ) , -0.7863991640641141 ); 
+teste( "Math.atan2 ( -0.5, 0.499 ) ", Math.atan2 ( -0.5, 0.499 ) , -0.7863991640641141 );
 
 
-teste( "Math.atan2 ( -0.5, -0.5 ) ", Math.atan2 ( -0.5, -0.5 ) , -2.356194490192345 ); 
+teste( "Math.atan2 ( -0.5, -0.5 ) ", Math.atan2 ( -0.5, -0.5 ) , -2.356194490192345 );
 
 
-test( "Math.max ( Number.POSITIVE_INFINITY, Number.POSITIVE_INFINITY ) ", Math.max ( Number.POSITIVE_INFINITY, Number.POSITIVE_INFINITY ) , Infinity ); 
+test( "Math.max ( Number.POSITIVE_INFINITY, Number.POSITIVE_INFINITY ) ", Math.max ( Number.POSITIVE_INFINITY, Number.POSITIVE_INFINITY ) , Infinity );
 
 
-test( "Math.max ( Number.POSITIVE_INFINITY, Number.NEGATIVE_INFINITY ) ", Math.max ( Number.POSITIVE_INFINITY, Number.NEGATIVE_INFINITY ) , Infinity ); 
+test( "Math.max ( Number.POSITIVE_INFINITY, Number.NEGATIVE_INFINITY ) ", Math.max ( Number.POSITIVE_INFINITY, Number.NEGATIVE_INFINITY ) , Infinity );
 
 
-test( "Math.max ( Number.POSITIVE_INFINITY, Number.MAX_VALUE ) ", Math.max ( Number.POSITIVE_INFINITY, Number.MAX_VALUE ) , Infinity ); 
+test( "Math.max ( Number.POSITIVE_INFINITY, Number.MAX_VALUE ) ", Math.max ( Number.POSITIVE_INFINITY, Number.MAX_VALUE ) , Infinity );
 
 
-test( "Math.max ( Number.POSITIVE_INFINITY, Number.MIN_VALUE ) ", Math.max ( Number.POSITIVE_INFINITY, Number.MIN_VALUE ) , Infinity ); 
+test( "Math.max ( Number.POSITIVE_INFINITY, Number.MIN_VALUE ) ", Math.max ( Number.POSITIVE_INFINITY, Number.MIN_VALUE ) , Infinity );
 
 
-test( "Math.max ( Number.POSITIVE_INFINITY, Number.NaN ) ", Math.max ( Number.POSITIVE_INFINITY, Number.NaN ) , Number.NaN ); 
+test( "Math.max ( Number.POSITIVE_INFINITY, Number.NaN ) ", Math.max ( Number.POSITIVE_INFINITY, Number.NaN ) , Number.NaN );
 
 
-test( "Math.max ( Number.POSITIVE_INFINITY, 0 ) ", Math.max ( Number.POSITIVE_INFINITY, 0 ) , Infinity ); 
+test( "Math.max ( Number.POSITIVE_INFINITY, 0 ) ", Math.max ( Number.POSITIVE_INFINITY, 0 ) , Infinity );
 
 
-test( "Math.max ( Number.POSITIVE_INFINITY, -0 ) ", Math.max ( Number.POSITIVE_INFINITY, -0 ) , Infinity ); 
+test( "Math.max ( Number.POSITIVE_INFINITY, -0 ) ", Math.max ( Number.POSITIVE_INFINITY, -0 ) , Infinity );
 
 
-test( "Math.max ( Number.POSITIVE_INFINITY, 1 ) ", Math.max ( Number.POSITIVE_INFINITY, 1 ) , Infinity ); 
+test( "Math.max ( Number.POSITIVE_INFINITY, 1 ) ", Math.max ( Number.POSITIVE_INFINITY, 1 ) , Infinity );
 
 
-test( "Math.max ( Number.POSITIVE_INFINITY, 1.012 ) ", Math.max ( Number.POSITIVE_INFINITY, 1.012 ) , Infinity ); 
+test( "Math.max ( Number.POSITIVE_INFINITY, 1.012 ) ", Math.max ( Number.POSITIVE_INFINITY, 1.012 ) , Infinity );
 
 
-test( "Math.max ( Number.POSITIVE_INFINITY, -1.12 ) ", Math.max ( Number.POSITIVE_INFINITY, -1.12 ) , Infinity ); 
+test( "Math.max ( Number.POSITIVE_INFINITY, -1.12 ) ", Math.max ( Number.POSITIVE_INFINITY, -1.12 ) , Infinity );
 
 
-test( "Math.max ( Number.POSITIVE_INFINITY, 0.499 ) ", Math.max ( Number.POSITIVE_INFINITY, 0.499 ) , Infinity ); 
+test( "Math.max ( Number.POSITIVE_INFINITY, 0.499 ) ", Math.max ( Number.POSITIVE_INFINITY, 0.499 ) , Infinity );
 
 
-test( "Math.max ( Number.POSITIVE_INFINITY, -0.5 ) ", Math.max ( Number.POSITIVE_INFINITY, -0.5 ) , Infinity ); 
+test( "Math.max ( Number.POSITIVE_INFINITY, -0.5 ) ", Math.max ( Number.POSITIVE_INFINITY, -0.5 ) , Infinity );
 
 
-test( "Math.max ( Number.NEGATIVE_INFINITY, Number.POSITIVE_INFINITY ) ", Math.max ( Number.NEGATIVE_INFINITY, Number.POSITIVE_INFINITY ) , Infinity ); 
+test( "Math.max ( Number.NEGATIVE_INFINITY, Number.POSITIVE_INFINITY ) ", Math.max ( Number.NEGATIVE_INFINITY, Number.POSITIVE_INFINITY ) , Infinity );
 
 
-test( "Math.max ( Number.NEGATIVE_INFINITY, Number.NEGATIVE_INFINITY ) ", Math.max ( Number.NEGATIVE_INFINITY, Number.NEGATIVE_INFINITY ) , -Infinity ); 
+test( "Math.max ( Number.NEGATIVE_INFINITY, Number.NEGATIVE_INFINITY ) ", Math.max ( Number.NEGATIVE_INFINITY, Number.NEGATIVE_INFINITY ) , -Infinity );
 
 
-test( "Math.max ( Number.NEGATIVE_INFINITY, Number.MAX_VALUE ) ", Math.max ( Number.NEGATIVE_INFINITY, Number.MAX_VALUE ) , Number.MAX_VALUE ); 
+test( "Math.max ( Number.NEGATIVE_INFINITY, Number.MAX_VALUE ) ", Math.max ( Number.NEGATIVE_INFINITY, Number.MAX_VALUE ) , Number.MAX_VALUE );
 
 
-test( "Math.max ( Number.NEGATIVE_INFINITY, Number.MIN_VALUE ) ", Math.max ( Number.NEGATIVE_INFINITY, Number.MIN_VALUE ) , Number.MIN_VALUE ); 
+test( "Math.max ( Number.NEGATIVE_INFINITY, Number.MIN_VALUE ) ", Math.max ( Number.NEGATIVE_INFINITY, Number.MIN_VALUE ) , Number.MIN_VALUE );
 
 
-test( "Math.max ( Number.NEGATIVE_INFINITY, Number.NaN ) ", Math.max ( Number.NEGATIVE_INFINITY, Number.NaN ) , Number.NaN ); 
+test( "Math.max ( Number.NEGATIVE_INFINITY, Number.NaN ) ", Math.max ( Number.NEGATIVE_INFINITY, Number.NaN ) , Number.NaN );
 
 
-test( "Math.max ( Number.NEGATIVE_INFINITY, 0 ) ", Math.max ( Number.NEGATIVE_INFINITY, 0 ) , 0 ); 
+test( "Math.max ( Number.NEGATIVE_INFINITY, 0 ) ", Math.max ( Number.NEGATIVE_INFINITY, 0 ) , 0 );
 
 
-test( "Math.max ( Number.NEGATIVE_INFINITY, -0 ) ", Math.max ( Number.NEGATIVE_INFINITY, -0 ) , 0 ); 
+test( "Math.max ( Number.NEGATIVE_INFINITY, -0 ) ", Math.max ( Number.NEGATIVE_INFINITY, -0 ) , 0 );
 
 
-test( "Math.max ( Number.NEGATIVE_INFINITY, 1 ) ", Math.max ( Number.NEGATIVE_INFINITY, 1 ) , 1 ); 
+test( "Math.max ( Number.NEGATIVE_INFINITY, 1 ) ", Math.max ( Number.NEGATIVE_INFINITY, 1 ) , 1 );
 
 
-test( "Math.max ( Number.NEGATIVE_INFINITY, 1.012 ) ", Math.max ( Number.NEGATIVE_INFINITY, 1.012 ) , 1.012 ); 
+test( "Math.max ( Number.NEGATIVE_INFINITY, 1.012 ) ", Math.max ( Number.NEGATIVE_INFINITY, 1.012 ) , 1.012 );
 
 
-test( "Math.max ( Number.NEGATIVE_INFINITY, -1.12 ) ", Math.max ( Number.NEGATIVE_INFINITY, -1.12 ) , -1.12 ); 
+test( "Math.max ( Number.NEGATIVE_INFINITY, -1.12 ) ", Math.max ( Number.NEGATIVE_INFINITY, -1.12 ) , -1.12 );
 
 
-test( "Math.max ( Number.NEGATIVE_INFINITY, 0.499 ) ", Math.max ( Number.NEGATIVE_INFINITY, 0.499 ) , 0.499 ); 
+test( "Math.max ( Number.NEGATIVE_INFINITY, 0.499 ) ", Math.max ( Number.NEGATIVE_INFINITY, 0.499 ) , 0.499 );
 
 
-test( "Math.max ( Number.NEGATIVE_INFINITY, -0.5 ) ", Math.max ( Number.NEGATIVE_INFINITY, -0.5 ) , -0.5 ); 
+test( "Math.max ( Number.NEGATIVE_INFINITY, -0.5 ) ", Math.max ( Number.NEGATIVE_INFINITY, -0.5 ) , -0.5 );
 
 
-test( "Math.max ( Number.MAX_VALUE, Number.POSITIVE_INFINITY ) ", Math.max ( Number.MAX_VALUE, Number.POSITIVE_INFINITY ) , Infinity ); 
+test( "Math.max ( Number.MAX_VALUE, Number.POSITIVE_INFINITY ) ", Math.max ( Number.MAX_VALUE, Number.POSITIVE_INFINITY ) , Infinity );
 
 
-test( "Math.max ( Number.MAX_VALUE, Number.NEGATIVE_INFINITY ) ", Math.max ( Number.MAX_VALUE, Number.NEGATIVE_INFINITY ) , Number.MAX_VALUE ); 
+test( "Math.max ( Number.MAX_VALUE, Number.NEGATIVE_INFINITY ) ", Math.max ( Number.MAX_VALUE, Number.NEGATIVE_INFINITY ) , Number.MAX_VALUE );
 
 
-test( "Math.max ( Number.MAX_VALUE, Number.MAX_VALUE ) ", Math.max ( Number.MAX_VALUE, Number.MAX_VALUE ) , Number.MAX_VALUE ); 
+test( "Math.max ( Number.MAX_VALUE, Number.MAX_VALUE ) ", Math.max ( Number.MAX_VALUE, Number.MAX_VALUE ) , Number.MAX_VALUE );
 
 
-test( "Math.max ( Number.MAX_VALUE, Number.MIN_VALUE ) ", Math.max ( Number.MAX_VALUE, Number.MIN_VALUE ) , Number.MAX_VALUE ); 
+test( "Math.max ( Number.MAX_VALUE, Number.MIN_VALUE ) ", Math.max ( Number.MAX_VALUE, Number.MIN_VALUE ) , Number.MAX_VALUE );
 
 
-test( "Math.max ( Number.MAX_VALUE, Number.NaN ) ", Math.max ( Number.MAX_VALUE, Number.NaN ) , Number.NaN ); 
+test( "Math.max ( Number.MAX_VALUE, Number.NaN ) ", Math.max ( Number.MAX_VALUE, Number.NaN ) , Number.NaN );
 
 
-test( "Math.max ( Number.MAX_VALUE, 0 ) ", Math.max ( Number.MAX_VALUE, 0 ) , Number.MAX_VALUE ); 
+test( "Math.max ( Number.MAX_VALUE, 0 ) ", Math.max ( Number.MAX_VALUE, 0 ) , Number.MAX_VALUE );
 
 
-test( "Math.max ( Number.MAX_VALUE, -0 ) ", Math.max ( Number.MAX_VALUE, -0 ) , Number.MAX_VALUE ); 
+test( "Math.max ( Number.MAX_VALUE, -0 ) ", Math.max ( Number.MAX_VALUE, -0 ) , Number.MAX_VALUE );
 
 
-test( "Math.max ( Number.MAX_VALUE, 1 ) ", Math.max ( Number.MAX_VALUE, 1 ) , Number.MAX_VALUE ); 
+test( "Math.max ( Number.MAX_VALUE, 1 ) ", Math.max ( Number.MAX_VALUE, 1 ) , Number.MAX_VALUE );
 
 
-test( "Math.max ( Number.MAX_VALUE, 1.012 ) ", Math.max ( Number.MAX_VALUE, 1.012 ) , Number.MAX_VALUE ); 
+test( "Math.max ( Number.MAX_VALUE, 1.012 ) ", Math.max ( Number.MAX_VALUE, 1.012 ) , Number.MAX_VALUE );
 
 
-test( "Math.max ( Number.MAX_VALUE, -1.12 ) ", Math.max ( Number.MAX_VALUE, -1.12 ) , Number.MAX_VALUE ); 
+test( "Math.max ( Number.MAX_VALUE, -1.12 ) ", Math.max ( Number.MAX_VALUE, -1.12 ) , Number.MAX_VALUE );
 
 
-test( "Math.max ( Number.MAX_VALUE, 0.499 ) ", Math.max ( Number.MAX_VALUE, 0.499 ) , Number.MAX_VALUE ); 
+test( "Math.max ( Number.MAX_VALUE, 0.499 ) ", Math.max ( Number.MAX_VALUE, 0.499 ) , Number.MAX_VALUE );
 
 
-test( "Math.max ( Number.MAX_VALUE, -0.5 ) ", Math.max ( Number.MAX_VALUE, -0.5 ) , Number.MAX_VALUE ); 
+test( "Math.max ( Number.MAX_VALUE, -0.5 ) ", Math.max ( Number.MAX_VALUE, -0.5 ) , Number.MAX_VALUE );
 
 
-test( "Math.max ( Number.MIN_VALUE, Number.POSITIVE_INFINITY ) ", Math.max ( Number.MIN_VALUE, Number.POSITIVE_INFINITY ) , Infinity ); 
+test( "Math.max ( Number.MIN_VALUE, Number.POSITIVE_INFINITY ) ", Math.max ( Number.MIN_VALUE, Number.POSITIVE_INFINITY ) , Infinity );
 
 
-test( "Math.max ( Number.MIN_VALUE, Number.NEGATIVE_INFINITY ) ", Math.max ( Number.MIN_VALUE, Number.NEGATIVE_INFINITY ) , Number.MIN_VALUE ); 
+test( "Math.max ( Number.MIN_VALUE, Number.NEGATIVE_INFINITY ) ", Math.max ( Number.MIN_VALUE, Number.NEGATIVE_INFINITY ) , Number.MIN_VALUE );
 
 
-test( "Math.max ( Number.MIN_VALUE, Number.MAX_VALUE ) ", Math.max ( Number.MIN_VALUE, Number.MAX_VALUE ) , Number.MAX_VALUE ); 
+test( "Math.max ( Number.MIN_VALUE, Number.MAX_VALUE ) ", Math.max ( Number.MIN_VALUE, Number.MAX_VALUE ) , Number.MAX_VALUE );
 
 
-test( "Math.max ( Number.MIN_VALUE, Number.MIN_VALUE ) ", Math.max ( Number.MIN_VALUE, Number.MIN_VALUE ) , Number.MIN_VALUE ); 
+test( "Math.max ( Number.MIN_VALUE, Number.MIN_VALUE ) ", Math.max ( Number.MIN_VALUE, Number.MIN_VALUE ) , Number.MIN_VALUE );
 
 
-test( "Math.max ( Number.MIN_VALUE, Number.NaN ) ", Math.max ( Number.MIN_VALUE, Number.NaN ) , Number.NaN ); 
+test( "Math.max ( Number.MIN_VALUE, Number.NaN ) ", Math.max ( Number.MIN_VALUE, Number.NaN ) , Number.NaN );
 
 
-test( "Math.max ( Number.MIN_VALUE, 0 ) ", Math.max ( Number.MIN_VALUE, 0 ) , Number.MIN_VALUE ); 
+test( "Math.max ( Number.MIN_VALUE, 0 ) ", Math.max ( Number.MIN_VALUE, 0 ) , Number.MIN_VALUE );
 
 
-test( "Math.max ( Number.MIN_VALUE, -0 ) ", Math.max ( Number.MIN_VALUE, -0 ) , Number.MIN_VALUE ); 
+test( "Math.max ( Number.MIN_VALUE, -0 ) ", Math.max ( Number.MIN_VALUE, -0 ) , Number.MIN_VALUE );
 
 
-test( "Math.max ( Number.MIN_VALUE, 1 ) ", Math.max ( Number.MIN_VALUE, 1 ) , 1 ); 
+test( "Math.max ( Number.MIN_VALUE, 1 ) ", Math.max ( Number.MIN_VALUE, 1 ) , 1 );
 
 
-test( "Math.max ( Number.MIN_VALUE, 1.012 ) ", Math.max ( Number.MIN_VALUE, 1.012 ) , 1.012 ); 
+test( "Math.max ( Number.MIN_VALUE, 1.012 ) ", Math.max ( Number.MIN_VALUE, 1.012 ) , 1.012 );
 
 
-test( "Math.max ( Number.MIN_VALUE, -1.12 ) ", Math.max ( Number.MIN_VALUE, -1.12 ) , Number.MIN_VALUE ); 
+test( "Math.max ( Number.MIN_VALUE, -1.12 ) ", Math.max ( Number.MIN_VALUE, -1.12 ) , Number.MIN_VALUE );
 /* WAS: 5e-324 */
 
-test( "Math.max ( Number.MIN_VALUE, 0.499 ) ", Math.max ( Number.MIN_VALUE, 0.499 ) , 0.499 ); 
+test( "Math.max ( Number.MIN_VALUE, 0.499 ) ", Math.max ( Number.MIN_VALUE, 0.499 ) , 0.499 );
 
 
-test( "Math.max ( Number.MIN_VALUE, -0.5 ) ", Math.max ( Number.MIN_VALUE, -0.5 ) , Number.MIN_VALUE ); 
+test( "Math.max ( Number.MIN_VALUE, -0.5 ) ", Math.max ( Number.MIN_VALUE, -0.5 ) , Number.MIN_VALUE );
 /* WAS: 5e-324 */
 
-test( "Math.max ( Number.NaN, Number.POSITIVE_INFINITY ) ", Math.max ( Number.NaN, Number.POSITIVE_INFINITY ) , Number.NaN ); 
+test( "Math.max ( Number.NaN, Number.POSITIVE_INFINITY ) ", Math.max ( Number.NaN, Number.POSITIVE_INFINITY ) , Number.NaN );
 
 
-test( "Math.max ( Number.NaN, Number.NEGATIVE_INFINITY ) ", Math.max ( Number.NaN, Number.NEGATIVE_INFINITY ) , Number.NaN ); 
+test( "Math.max ( Number.NaN, Number.NEGATIVE_INFINITY ) ", Math.max ( Number.NaN, Number.NEGATIVE_INFINITY ) , Number.NaN );
 
 
-test( "Math.max ( Number.NaN, Number.MAX_VALUE ) ", Math.max ( Number.NaN, Number.MAX_VALUE ) , Number.NaN ); 
+test( "Math.max ( Number.NaN, Number.MAX_VALUE ) ", Math.max ( Number.NaN, Number.MAX_VALUE ) , Number.NaN );
 
 
-test( "Math.max ( Number.NaN, Number.MIN_VALUE ) ", Math.max ( Number.NaN, Number.MIN_VALUE ) , Number.NaN ); 
+test( "Math.max ( Number.NaN, Number.MIN_VALUE ) ", Math.max ( Number.NaN, Number.MIN_VALUE ) , Number.NaN );
 
 
-test( "Math.max ( Number.NaN, Number.NaN ) ", Math.max ( Number.NaN, Number.NaN ) , Number.NaN ); 
+test( "Math.max ( Number.NaN, Number.NaN ) ", Math.max ( Number.NaN, Number.NaN ) , Number.NaN );
 
 
-test( "Math.max ( Number.NaN, 0 ) ", Math.max ( Number.NaN, 0 ) , Number.NaN ); 
+test( "Math.max ( Number.NaN, 0 ) ", Math.max ( Number.NaN, 0 ) , Number.NaN );
 
 
-test( "Math.max ( Number.NaN, -0 ) ", Math.max ( Number.NaN, -0 ) , Number.NaN ); 
+test( "Math.max ( Number.NaN, -0 ) ", Math.max ( Number.NaN, -0 ) , Number.NaN );
 
 
-test( "Math.max ( Number.NaN, 1 ) ", Math.max ( Number.NaN, 1 ) , Number.NaN ); 
+test( "Math.max ( Number.NaN, 1 ) ", Math.max ( Number.NaN, 1 ) , Number.NaN );
 
 
-test( "Math.max ( Number.NaN, 1.012 ) ", Math.max ( Number.NaN, 1.012 ) , Number.NaN ); 
+test( "Math.max ( Number.NaN, 1.012 ) ", Math.max ( Number.NaN, 1.012 ) , Number.NaN );
 
 
-test( "Math.max ( Number.NaN, -1.12 ) ", Math.max ( Number.NaN, -1.12 ) , Number.NaN ); 
+test( "Math.max ( Number.NaN, -1.12 ) ", Math.max ( Number.NaN, -1.12 ) , Number.NaN );
 
 
-test( "Math.max ( Number.NaN, 0.499 ) ", Math.max ( Number.NaN, 0.499 ) , Number.NaN ); 
+test( "Math.max ( Number.NaN, 0.499 ) ", Math.max ( Number.NaN, 0.499 ) , Number.NaN );
 
 
-test( "Math.max ( Number.NaN, -0.5 ) ", Math.max ( Number.NaN, -0.5 ) , Number.NaN ); 
+test( "Math.max ( Number.NaN, -0.5 ) ", Math.max ( Number.NaN, -0.5 ) , Number.NaN );
 
 
-test( "Math.max ( 0, Number.POSITIVE_INFINITY ) ", Math.max ( 0, Number.POSITIVE_INFINITY ) , Infinity ); 
+test( "Math.max ( 0, Number.POSITIVE_INFINITY ) ", Math.max ( 0, Number.POSITIVE_INFINITY ) , Infinity );
 
 
-test( "Math.max ( 0, Number.NEGATIVE_INFINITY ) ", Math.max ( 0, Number.NEGATIVE_INFINITY ) , 0 ); 
+test( "Math.max ( 0, Number.NEGATIVE_INFINITY ) ", Math.max ( 0, Number.NEGATIVE_INFINITY ) , 0 );
 
 
-test( "Math.max ( 0, Number.MAX_VALUE ) ", Math.max ( 0, Number.MAX_VALUE ) , Number.MAX_VALUE ); 
+test( "Math.max ( 0, Number.MAX_VALUE ) ", Math.max ( 0, Number.MAX_VALUE ) , Number.MAX_VALUE );
 
 
-test( "Math.max ( 0, Number.MIN_VALUE ) ", Math.max ( 0, Number.MIN_VALUE ) , Number.MIN_VALUE ); 
+test( "Math.max ( 0, Number.MIN_VALUE ) ", Math.max ( 0, Number.MIN_VALUE ) , Number.MIN_VALUE );
 
 
-test( "Math.max ( 0, Number.NaN ) ", Math.max ( 0, Number.NaN ) , Number.NaN ); 
+test( "Math.max ( 0, Number.NaN ) ", Math.max ( 0, Number.NaN ) , Number.NaN );
 
 
-test( "Math.max ( 0, 0 ) ", Math.max ( 0, 0 ) , 0 ); 
+test( "Math.max ( 0, 0 ) ", Math.max ( 0, 0 ) , 0 );
 
 
-test( "Math.max ( 0, -0 ) ", Math.max ( 0, -0 ) , 0 ); 
+test( "Math.max ( 0, -0 ) ", Math.max ( 0, -0 ) , 0 );
 
 
-test( "Math.max ( 0, 1 ) ", Math.max ( 0, 1 ) , 1 ); 
+test( "Math.max ( 0, 1 ) ", Math.max ( 0, 1 ) , 1 );
 
 
-test( "Math.max ( 0, 1.012 ) ", Math.max ( 0, 1.012 ) , 1.012 ); 
+test( "Math.max ( 0, 1.012 ) ", Math.max ( 0, 1.012 ) , 1.012 );
 
 
-test( "Math.max ( 0, -1.12 ) ", Math.max ( 0, -1.12 ) , 0 ); 
+test( "Math.max ( 0, -1.12 ) ", Math.max ( 0, -1.12 ) , 0 );
 
 
-test( "Math.max ( 0, 0.499 ) ", Math.max ( 0, 0.499 ) , 0.499 ); 
+test( "Math.max ( 0, 0.499 ) ", Math.max ( 0, 0.499 ) , 0.499 );
 
 
-test( "Math.max ( 0, -0.5 ) ", Math.max ( 0, -0.5 ) , 0 ); 
+test( "Math.max ( 0, -0.5 ) ", Math.max ( 0, -0.5 ) , 0 );
 
 
-test( "Math.max ( -0, Number.POSITIVE_INFINITY ) ", Math.max ( -0, Number.POSITIVE_INFINITY ) , Infinity ); 
+test( "Math.max ( -0, Number.POSITIVE_INFINITY ) ", Math.max ( -0, Number.POSITIVE_INFINITY ) , Infinity );
 
 
-test( "Math.max ( -0, Number.NEGATIVE_INFINITY ) ", Math.max ( -0, Number.NEGATIVE_INFINITY ) , 0 ); 
+test( "Math.max ( -0, Number.NEGATIVE_INFINITY ) ", Math.max ( -0, Number.NEGATIVE_INFINITY ) , 0 );
 
 
-test( "Math.max ( -0, Number.MAX_VALUE ) ", Math.max ( -0, Number.MAX_VALUE ) , Number.MAX_VALUE ); 
+test( "Math.max ( -0, Number.MAX_VALUE ) ", Math.max ( -0, Number.MAX_VALUE ) , Number.MAX_VALUE );
 
 
-test( "Math.max ( -0, Number.MIN_VALUE ) ", Math.max ( -0, Number.MIN_VALUE ) , Number.MIN_VALUE ); 
+test( "Math.max ( -0, Number.MIN_VALUE ) ", Math.max ( -0, Number.MIN_VALUE ) , Number.MIN_VALUE );
 
 
-test( "Math.max ( -0, Number.NaN ) ", Math.max ( -0, Number.NaN ) , Number.NaN ); 
+test( "Math.max ( -0, Number.NaN ) ", Math.max ( -0, Number.NaN ) , Number.NaN );
 
 
-test( "Math.max ( -0, 0 ) ", Math.max ( -0, 0 ) , 0 ); 
+test( "Math.max ( -0, 0 ) ", Math.max ( -0, 0 ) , 0 );
 
 
-test( "Math.max ( -0, -0 ) ", Math.max ( -0, -0 ) , 0 ); 
+test( "Math.max ( -0, -0 ) ", Math.max ( -0, -0 ) , 0 );
 
 
-test( "Math.max ( -0, 1 ) ", Math.max ( -0, 1 ) , 1 ); 
+test( "Math.max ( -0, 1 ) ", Math.max ( -0, 1 ) , 1 );
 
 
-test( "Math.max ( -0, 1.012 ) ", Math.max ( -0, 1.012 ) , 1.012 ); 
+test( "Math.max ( -0, 1.012 ) ", Math.max ( -0, 1.012 ) , 1.012 );
 
 
-test( "Math.max ( -0, -1.12 ) ", Math.max ( -0, -1.12 ) , 0 ); 
+test( "Math.max ( -0, -1.12 ) ", Math.max ( -0, -1.12 ) , 0 );
 
 
-test( "Math.max ( -0, 0.499 ) ", Math.max ( -0, 0.499 ) , 0.499 ); 
+test( "Math.max ( -0, 0.499 ) ", Math.max ( -0, 0.499 ) , 0.499 );
 
 
-test( "Math.max ( -0, -0.5 ) ", Math.max ( -0, -0.5 ) , 0 ); 
+test( "Math.max ( -0, -0.5 ) ", Math.max ( -0, -0.5 ) , 0 );
 
 
-test( "Math.max ( 1, Number.POSITIVE_INFINITY ) ", Math.max ( 1, Number.POSITIVE_INFINITY ) , Infinity ); 
+test( "Math.max ( 1, Number.POSITIVE_INFINITY ) ", Math.max ( 1, Number.POSITIVE_INFINITY ) , Infinity );
 
 
-test( "Math.max ( 1, Number.NEGATIVE_INFINITY ) ", Math.max ( 1, Number.NEGATIVE_INFINITY ) , 1 ); 
+test( "Math.max ( 1, Number.NEGATIVE_INFINITY ) ", Math.max ( 1, Number.NEGATIVE_INFINITY ) , 1 );
 
 
-test( "Math.max ( 1, Number.MAX_VALUE ) ", Math.max ( 1, Number.MAX_VALUE ) , Number.MAX_VALUE ); 
+test( "Math.max ( 1, Number.MAX_VALUE ) ", Math.max ( 1, Number.MAX_VALUE ) , Number.MAX_VALUE );
 
 
-test( "Math.max ( 1, Number.MIN_VALUE ) ", Math.max ( 1, Number.MIN_VALUE ) , 1 ); 
+test( "Math.max ( 1, Number.MIN_VALUE ) ", Math.max ( 1, Number.MIN_VALUE ) , 1 );
 
 
-test( "Math.max ( 1, Number.NaN ) ", Math.max ( 1, Number.NaN ) , Number.NaN ); 
+test( "Math.max ( 1, Number.NaN ) ", Math.max ( 1, Number.NaN ) , Number.NaN );
 
 
-test( "Math.max ( 1, 0 ) ", Math.max ( 1, 0 ) , 1 ); 
+test( "Math.max ( 1, 0 ) ", Math.max ( 1, 0 ) , 1 );
 
 
-test( "Math.max ( 1, -0 ) ", Math.max ( 1, -0 ) , 1 ); 
+test( "Math.max ( 1, -0 ) ", Math.max ( 1, -0 ) , 1 );
 
 
-test( "Math.max ( 1, 1 ) ", Math.max ( 1, 1 ) , 1 ); 
+test( "Math.max ( 1, 1 ) ", Math.max ( 1, 1 ) , 1 );
 
 
-test( "Math.max ( 1, 1.012 ) ", Math.max ( 1, 1.012 ) , 1.012 ); 
+test( "Math.max ( 1, 1.012 ) ", Math.max ( 1, 1.012 ) , 1.012 );
 
 
-test( "Math.max ( 1, -1.12 ) ", Math.max ( 1, -1.12 ) , 1 ); 
+test( "Math.max ( 1, -1.12 ) ", Math.max ( 1, -1.12 ) , 1 );
 
 
-test( "Math.max ( 1, 0.499 ) ", Math.max ( 1, 0.499 ) , 1 ); 
+test( "Math.max ( 1, 0.499 ) ", Math.max ( 1, 0.499 ) , 1 );
 
 
-test( "Math.max ( 1, -0.5 ) ", Math.max ( 1, -0.5 ) , 1 ); 
+test( "Math.max ( 1, -0.5 ) ", Math.max ( 1, -0.5 ) , 1 );
 
 
-test( "Math.max ( 1.012, Number.POSITIVE_INFINITY ) ", Math.max ( 1.012, Number.POSITIVE_INFINITY ) , Infinity ); 
+test( "Math.max ( 1.012, Number.POSITIVE_INFINITY ) ", Math.max ( 1.012, Number.POSITIVE_INFINITY ) , Infinity );
 
 
-test( "Math.max ( 1.012, Number.NEGATIVE_INFINITY ) ", Math.max ( 1.012, Number.NEGATIVE_INFINITY ) , 1.012 ); 
+test( "Math.max ( 1.012, Number.NEGATIVE_INFINITY ) ", Math.max ( 1.012, Number.NEGATIVE_INFINITY ) , 1.012 );
 
 
-test( "Math.max ( 1.012, Number.MAX_VALUE ) ", Math.max ( 1.012, Number.MAX_VALUE ) , Number.MAX_VALUE ); 
+test( "Math.max ( 1.012, Number.MAX_VALUE ) ", Math.max ( 1.012, Number.MAX_VALUE ) , Number.MAX_VALUE );
 
 
-test( "Math.max ( 1.012, Number.MIN_VALUE ) ", Math.max ( 1.012, Number.MIN_VALUE ) , 1.012 ); 
+test( "Math.max ( 1.012, Number.MIN_VALUE ) ", Math.max ( 1.012, Number.MIN_VALUE ) , 1.012 );
 
 
-test( "Math.max ( 1.012, Number.NaN ) ", Math.max ( 1.012, Number.NaN ) , Number.NaN ); 
+test( "Math.max ( 1.012, Number.NaN ) ", Math.max ( 1.012, Number.NaN ) , Number.NaN );
 
 
-test( "Math.max ( 1.012, 0 ) ", Math.max ( 1.012, 0 ) , 1.012 ); 
+test( "Math.max ( 1.012, 0 ) ", Math.max ( 1.012, 0 ) , 1.012 );
 
 
-test( "Math.max ( 1.012, -0 ) ", Math.max ( 1.012, -0 ) , 1.012 ); 
+test( "Math.max ( 1.012, -0 ) ", Math.max ( 1.012, -0 ) , 1.012 );
 
 
-test( "Math.max ( 1.012, 1 ) ", Math.max ( 1.012, 1 ) , 1.012 ); 
+test( "Math.max ( 1.012, 1 ) ", Math.max ( 1.012, 1 ) , 1.012 );
 
 
-test( "Math.max ( 1.012, 1.012 ) ", Math.max ( 1.012, 1.012 ) , 1.012 ); 
+test( "Math.max ( 1.012, 1.012 ) ", Math.max ( 1.012, 1.012 ) , 1.012 );
 
 
-test( "Math.max ( 1.012, -1.12 ) ", Math.max ( 1.012, -1.12 ) , 1.012 ); 
+test( "Math.max ( 1.012, -1.12 ) ", Math.max ( 1.012, -1.12 ) , 1.012 );
 
 
-test( "Math.max ( 1.012, 0.499 ) ", Math.max ( 1.012, 0.499 ) , 1.012 ); 
+test( "Math.max ( 1.012, 0.499 ) ", Math.max ( 1.012, 0.499 ) , 1.012 );
 
 
-test( "Math.max ( 1.012, -0.5 ) ", Math.max ( 1.012, -0.5 ) , 1.012 ); 
+test( "Math.max ( 1.012, -0.5 ) ", Math.max ( 1.012, -0.5 ) , 1.012 );
 
 
-test( "Math.max ( -1.12, Number.POSITIVE_INFINITY ) ", Math.max ( -1.12, Number.POSITIVE_INFINITY ) , Infinity ); 
+test( "Math.max ( -1.12, Number.POSITIVE_INFINITY ) ", Math.max ( -1.12, Number.POSITIVE_INFINITY ) , Infinity );
 
 
-test( "Math.max ( -1.12, Number.NEGATIVE_INFINITY ) ", Math.max ( -1.12, Number.NEGATIVE_INFINITY ) , -1.12 ); 
+test( "Math.max ( -1.12, Number.NEGATIVE_INFINITY ) ", Math.max ( -1.12, Number.NEGATIVE_INFINITY ) , -1.12 );
 
 
-test( "Math.max ( -1.12, Number.MAX_VALUE ) ", Math.max ( -1.12, Number.MAX_VALUE ) , Number.MAX_VALUE ); 
+test( "Math.max ( -1.12, Number.MAX_VALUE ) ", Math.max ( -1.12, Number.MAX_VALUE ) , Number.MAX_VALUE );
 
 
-test( "Math.max ( -1.12, Number.MIN_VALUE ) ", Math.max ( -1.12, Number.MIN_VALUE ) , Number.MIN_VALUE ); 
+test( "Math.max ( -1.12, Number.MIN_VALUE ) ", Math.max ( -1.12, Number.MIN_VALUE ) , Number.MIN_VALUE );
 /* WAS: 5e-324 */
 
-test( "Math.max ( -1.12, Number.NaN ) ", Math.max ( -1.12, Number.NaN ) , Number.NaN ); 
+test( "Math.max ( -1.12, Number.NaN ) ", Math.max ( -1.12, Number.NaN ) , Number.NaN );
 
 
-test( "Math.max ( -1.12, 0 ) ", Math.max ( -1.12, 0 ) , 0 ); 
+test( "Math.max ( -1.12, 0 ) ", Math.max ( -1.12, 0 ) , 0 );
 
 
-test( "Math.max ( -1.12, -0 ) ", Math.max ( -1.12, -0 ) , 0 ); 
+test( "Math.max ( -1.12, -0 ) ", Math.max ( -1.12, -0 ) , 0 );
 
 
-test( "Math.max ( -1.12, 1 ) ", Math.max ( -1.12, 1 ) , 1 ); 
+test( "Math.max ( -1.12, 1 ) ", Math.max ( -1.12, 1 ) , 1 );
 
 
-test( "Math.max ( -1.12, 1.012 ) ", Math.max ( -1.12, 1.012 ) , 1.012 ); 
+test( "Math.max ( -1.12, 1.012 ) ", Math.max ( -1.12, 1.012 ) , 1.012 );
 
 
-test( "Math.max ( -1.12, -1.12 ) ", Math.max ( -1.12, -1.12 ) , -1.12 ); 
+test( "Math.max ( -1.12, -1.12 ) ", Math.max ( -1.12, -1.12 ) , -1.12 );
 
 
-test( "Math.max ( -1.12, 0.499 ) ", Math.max ( -1.12, 0.499 ) , 0.499 ); 
+test( "Math.max ( -1.12, 0.499 ) ", Math.max ( -1.12, 0.499 ) , 0.499 );
 
 
-test( "Math.max ( -1.12, -0.5 ) ", Math.max ( -1.12, -0.5 ) , -0.5 ); 
+test( "Math.max ( -1.12, -0.5 ) ", Math.max ( -1.12, -0.5 ) , -0.5 );
 
 
-test( "Math.max ( 0.499, Number.POSITIVE_INFINITY ) ", Math.max ( 0.499, Number.POSITIVE_INFINITY ) , Infinity ); 
+test( "Math.max ( 0.499, Number.POSITIVE_INFINITY ) ", Math.max ( 0.499, Number.POSITIVE_INFINITY ) , Infinity );
 
 
-test( "Math.max ( 0.499, Number.NEGATIVE_INFINITY ) ", Math.max ( 0.499, Number.NEGATIVE_INFINITY ) , 0.499 ); 
+test( "Math.max ( 0.499, Number.NEGATIVE_INFINITY ) ", Math.max ( 0.499, Number.NEGATIVE_INFINITY ) , 0.499 );
 
 
-test( "Math.max ( 0.499, Number.MAX_VALUE ) ", Math.max ( 0.499, Number.MAX_VALUE ) , Number.MAX_VALUE ); 
+test( "Math.max ( 0.499, Number.MAX_VALUE ) ", Math.max ( 0.499, Number.MAX_VALUE ) , Number.MAX_VALUE );
 
 
-test( "Math.max ( 0.499, Number.MIN_VALUE ) ", Math.max ( 0.499, Number.MIN_VALUE ) , 0.499 ); 
+test( "Math.max ( 0.499, Number.MIN_VALUE ) ", Math.max ( 0.499, Number.MIN_VALUE ) , 0.499 );
 
 
-test( "Math.max ( 0.499, Number.NaN ) ", Math.max ( 0.499, Number.NaN ) , Number.NaN ); 
+test( "Math.max ( 0.499, Number.NaN ) ", Math.max ( 0.499, Number.NaN ) , Number.NaN );
 
 
-test( "Math.max ( 0.499, 0 ) ", Math.max ( 0.499, 0 ) , 0.499 ); 
+test( "Math.max ( 0.499, 0 ) ", Math.max ( 0.499, 0 ) , 0.499 );
 
 
-test( "Math.max ( 0.499, -0 ) ", Math.max ( 0.499, -0 ) , 0.499 ); 
+test( "Math.max ( 0.499, -0 ) ", Math.max ( 0.499, -0 ) , 0.499 );
 
 
-test( "Math.max ( 0.499, 1 ) ", Math.max ( 0.499, 1 ) , 1 ); 
+test( "Math.max ( 0.499, 1 ) ", Math.max ( 0.499, 1 ) , 1 );
 
 
-test( "Math.max ( 0.499, 1.012 ) ", Math.max ( 0.499, 1.012 ) , 1.012 ); 
+test( "Math.max ( 0.499, 1.012 ) ", Math.max ( 0.499, 1.012 ) , 1.012 );
 
 
-test( "Math.max ( 0.499, -1.12 ) ", Math.max ( 0.499, -1.12 ) , 0.499 ); 
+test( "Math.max ( 0.499, -1.12 ) ", Math.max ( 0.499, -1.12 ) , 0.499 );
 
 
-test( "Math.max ( 0.499, 0.499 ) ", Math.max ( 0.499, 0.499 ) , 0.499 ); 
+test( "Math.max ( 0.499, 0.499 ) ", Math.max ( 0.499, 0.499 ) , 0.499 );
 
 
-test( "Math.max ( 0.499, -0.5 ) ", Math.max ( 0.499, -0.5 ) , 0.499 ); 
+test( "Math.max ( 0.499, -0.5 ) ", Math.max ( 0.499, -0.5 ) , 0.499 );
 
 
-test( "Math.max ( -0.5, Number.POSITIVE_INFINITY ) ", Math.max ( -0.5, Number.POSITIVE_INFINITY ) , Infinity ); 
+test( "Math.max ( -0.5, Number.POSITIVE_INFINITY ) ", Math.max ( -0.5, Number.POSITIVE_INFINITY ) , Infinity );
 
 
-test( "Math.max ( -0.5, Number.NEGATIVE_INFINITY ) ", Math.max ( -0.5, Number.NEGATIVE_INFINITY ) , -0.5 ); 
+test( "Math.max ( -0.5, Number.NEGATIVE_INFINITY ) ", Math.max ( -0.5, Number.NEGATIVE_INFINITY ) , -0.5 );
 
 
-test( "Math.max ( -0.5, Number.MAX_VALUE ) ", Math.max ( -0.5, Number.MAX_VALUE ) , Number.MAX_VALUE ); 
+test( "Math.max ( -0.5, Number.MAX_VALUE ) ", Math.max ( -0.5, Number.MAX_VALUE ) , Number.MAX_VALUE );
 
 
-test( "Math.max ( -0.5, Number.MIN_VALUE ) ", Math.max ( -0.5, Number.MIN_VALUE ) , Number.MIN_VALUE ); 
+test( "Math.max ( -0.5, Number.MIN_VALUE ) ", Math.max ( -0.5, Number.MIN_VALUE ) , Number.MIN_VALUE );
 
 
-test( "Math.max ( -0.5, Number.NaN ) ", Math.max ( -0.5, Number.NaN ) , Number.NaN ); 
+test( "Math.max ( -0.5, Number.NaN ) ", Math.max ( -0.5, Number.NaN ) , Number.NaN );
 
 
-test( "Math.max ( -0.5, 0 ) ", Math.max ( -0.5, 0 ) , 0 ); 
+test( "Math.max ( -0.5, 0 ) ", Math.max ( -0.5, 0 ) , 0 );
 
 
-test( "Math.max ( -0.5, -0 ) ", Math.max ( -0.5, -0 ) , 0 ); 
+test( "Math.max ( -0.5, -0 ) ", Math.max ( -0.5, -0 ) , 0 );
 
 
-test( "Math.max ( -0.5, 1 ) ", Math.max ( -0.5, 1 ) , 1 ); 
+test( "Math.max ( -0.5, 1 ) ", Math.max ( -0.5, 1 ) , 1 );
 
 
-test( "Math.max ( -0.5, 1.012 ) ", Math.max ( -0.5, 1.012 ) , 1.012 ); 
+test( "Math.max ( -0.5, 1.012 ) ", Math.max ( -0.5, 1.012 ) , 1.012 );
 
 
-test( "Math.max ( -0.5, -1.12 ) ", Math.max ( -0.5, -1.12 ) , -0.5 ); 
+test( "Math.max ( -0.5, -1.12 ) ", Math.max ( -0.5, -1.12 ) , -0.5 );
 
 
-test( "Math.max ( -0.5, 0.499 ) ", Math.max ( -0.5, 0.499 ) , 0.499 ); 
+test( "Math.max ( -0.5, 0.499 ) ", Math.max ( -0.5, 0.499 ) , 0.499 );
 
 
-test( "Math.max ( -0.5, -0.5 ) ", Math.max ( -0.5, -0.5 ) , -0.5 ); 
+test( "Math.max ( -0.5, -0.5 ) ", Math.max ( -0.5, -0.5 ) , -0.5 );
 
-test( "Math.max ( <I>no parameters</I> ) ", Math.max ( ) , -Infinity ); 
+test( "Math.max ( <I>no parameters</I> ) ", Math.max ( ) , -Infinity );
 
 
-test( "Math.min ( Number.POSITIVE_INFINITY, Number.POSITIVE_INFINITY ) ", Math.min ( Number.POSITIVE_INFINITY, Number.POSITIVE_INFINITY ) , Infinity ); 
+test( "Math.min ( Number.POSITIVE_INFINITY, Number.POSITIVE_INFINITY ) ", Math.min ( Number.POSITIVE_INFINITY, Number.POSITIVE_INFINITY ) , Infinity );
 
 
-test( "Math.min ( Number.POSITIVE_INFINITY, Number.NEGATIVE_INFINITY ) ", Math.min ( Number.POSITIVE_INFINITY, Number.NEGATIVE_INFINITY ) , -Infinity ); 
+test( "Math.min ( Number.POSITIVE_INFINITY, Number.NEGATIVE_INFINITY ) ", Math.min ( Number.POSITIVE_INFINITY, Number.NEGATIVE_INFINITY ) , -Infinity );
 
 
-test( "Math.min ( Number.POSITIVE_INFINITY, Number.MAX_VALUE ) ", Math.min ( Number.POSITIVE_INFINITY, Number.MAX_VALUE ) , Number.MAX_VALUE ); 
+test( "Math.min ( Number.POSITIVE_INFINITY, Number.MAX_VALUE ) ", Math.min ( Number.POSITIVE_INFINITY, Number.MAX_VALUE ) , Number.MAX_VALUE );
 
 
-test( "Math.min ( Number.POSITIVE_INFINITY, Number.MIN_VALUE ) ", Math.min ( Number.POSITIVE_INFINITY, Number.MIN_VALUE ) , Number.MIN_VALUE ); 
+test( "Math.min ( Number.POSITIVE_INFINITY, Number.MIN_VALUE ) ", Math.min ( Number.POSITIVE_INFINITY, Number.MIN_VALUE ) , Number.MIN_VALUE );
 
 
-test( "Math.min ( Number.POSITIVE_INFINITY, Number.NaN ) ", Math.min ( Number.POSITIVE_INFINITY, Number.NaN ) , Number.NaN ); 
+test( "Math.min ( Number.POSITIVE_INFINITY, Number.NaN ) ", Math.min ( Number.POSITIVE_INFINITY, Number.NaN ) , Number.NaN );
 
 
-test( "Math.min ( Number.POSITIVE_INFINITY, 0 ) ", Math.min ( Number.POSITIVE_INFINITY, 0 ) , 0 ); 
+test( "Math.min ( Number.POSITIVE_INFINITY, 0 ) ", Math.min ( Number.POSITIVE_INFINITY, 0 ) , 0 );
 
 
-test( "Math.min ( Number.POSITIVE_INFINITY, -0 ) ", Math.min ( Number.POSITIVE_INFINITY, -0 ) , 0 ); 
+test( "Math.min ( Number.POSITIVE_INFINITY, -0 ) ", Math.min ( Number.POSITIVE_INFINITY, -0 ) , 0 );
 
 
-test( "Math.min ( Number.POSITIVE_INFINITY, 1 ) ", Math.min ( Number.POSITIVE_INFINITY, 1 ) , 1 ); 
+test( "Math.min ( Number.POSITIVE_INFINITY, 1 ) ", Math.min ( Number.POSITIVE_INFINITY, 1 ) , 1 );
 
 
-test( "Math.min ( Number.POSITIVE_INFINITY, 1.012 ) ", Math.min ( Number.POSITIVE_INFINITY, 1.012 ) , 1.012 ); 
+test( "Math.min ( Number.POSITIVE_INFINITY, 1.012 ) ", Math.min ( Number.POSITIVE_INFINITY, 1.012 ) , 1.012 );
 
 
-test( "Math.min ( Number.POSITIVE_INFINITY, -1.12 ) ", Math.min ( Number.POSITIVE_INFINITY, -1.12 ) , -1.12 ); 
+test( "Math.min ( Number.POSITIVE_INFINITY, -1.12 ) ", Math.min ( Number.POSITIVE_INFINITY, -1.12 ) , -1.12 );
 
 
-test( "Math.min ( Number.POSITIVE_INFINITY, 0.499 ) ", Math.min ( Number.POSITIVE_INFINITY, 0.499 ) , 0.499 ); 
+test( "Math.min ( Number.POSITIVE_INFINITY, 0.499 ) ", Math.min ( Number.POSITIVE_INFINITY, 0.499 ) , 0.499 );
 
 
-test( "Math.min ( Number.POSITIVE_INFINITY, -0.5 ) ", Math.min ( Number.POSITIVE_INFINITY, -0.5 ) , -0.5 ); 
+test( "Math.min ( Number.POSITIVE_INFINITY, -0.5 ) ", Math.min ( Number.POSITIVE_INFINITY, -0.5 ) , -0.5 );
 
 
-test( "Math.min ( Number.NEGATIVE_INFINITY, Number.POSITIVE_INFINITY ) ", Math.min ( Number.NEGATIVE_INFINITY, Number.POSITIVE_INFINITY ) , -Infinity ); 
+test( "Math.min ( Number.NEGATIVE_INFINITY, Number.POSITIVE_INFINITY ) ", Math.min ( Number.NEGATIVE_INFINITY, Number.POSITIVE_INFINITY ) , -Infinity );
 
 
-test( "Math.min ( Number.NEGATIVE_INFINITY, Number.NEGATIVE_INFINITY ) ", Math.min ( Number.NEGATIVE_INFINITY, Number.NEGATIVE_INFINITY ) , -Infinity ); 
+test( "Math.min ( Number.NEGATIVE_INFINITY, Number.NEGATIVE_INFINITY ) ", Math.min ( Number.NEGATIVE_INFINITY, Number.NEGATIVE_INFINITY ) , -Infinity );
 
 
-test( "Math.min ( Number.NEGATIVE_INFINITY, Number.MAX_VALUE ) ", Math.min ( Number.NEGATIVE_INFINITY, Number.MAX_VALUE ) , -Infinity ); 
+test( "Math.min ( Number.NEGATIVE_INFINITY, Number.MAX_VALUE ) ", Math.min ( Number.NEGATIVE_INFINITY, Number.MAX_VALUE ) , -Infinity );
 
 
-test( "Math.min ( Number.NEGATIVE_INFINITY, Number.MIN_VALUE ) ", Math.min ( Number.NEGATIVE_INFINITY, Number.MIN_VALUE ) , -Infinity ); 
+test( "Math.min ( Number.NEGATIVE_INFINITY, Number.MIN_VALUE ) ", Math.min ( Number.NEGATIVE_INFINITY, Number.MIN_VALUE ) , -Infinity );
 
 
-test( "Math.min ( Number.NEGATIVE_INFINITY, Number.NaN ) ", Math.min ( Number.NEGATIVE_INFINITY, Number.NaN ) , Number.NaN ); 
+test( "Math.min ( Number.NEGATIVE_INFINITY, Number.NaN ) ", Math.min ( Number.NEGATIVE_INFINITY, Number.NaN ) , Number.NaN );
 
 
-test( "Math.min ( Number.NEGATIVE_INFINITY, 0 ) ", Math.min ( Number.NEGATIVE_INFINITY, 0 ) , -Infinity ); 
+test( "Math.min ( Number.NEGATIVE_INFINITY, 0 ) ", Math.min ( Number.NEGATIVE_INFINITY, 0 ) , -Infinity );
 
 
-test( "Math.min ( Number.NEGATIVE_INFINITY, -0 ) ", Math.min ( Number.NEGATIVE_INFINITY, -0 ) , -Infinity ); 
+test( "Math.min ( Number.NEGATIVE_INFINITY, -0 ) ", Math.min ( Number.NEGATIVE_INFINITY, -0 ) , -Infinity );
 
 
-test( "Math.min ( Number.NEGATIVE_INFINITY, 1 ) ", Math.min ( Number.NEGATIVE_INFINITY, 1 ) , -Infinity ); 
+test( "Math.min ( Number.NEGATIVE_INFINITY, 1 ) ", Math.min ( Number.NEGATIVE_INFINITY, 1 ) , -Infinity );
 
 
-test( "Math.min ( Number.NEGATIVE_INFINITY, 1.012 ) ", Math.min ( Number.NEGATIVE_INFINITY, 1.012 ) , -Infinity ); 
+test( "Math.min ( Number.NEGATIVE_INFINITY, 1.012 ) ", Math.min ( Number.NEGATIVE_INFINITY, 1.012 ) , -Infinity );
 
 
-test( "Math.min ( Number.NEGATIVE_INFINITY, -1.12 ) ", Math.min ( Number.NEGATIVE_INFINITY, -1.12 ) , -Infinity ); 
+test( "Math.min ( Number.NEGATIVE_INFINITY, -1.12 ) ", Math.min ( Number.NEGATIVE_INFINITY, -1.12 ) , -Infinity );
 
 
-test( "Math.min ( Number.NEGATIVE_INFINITY, 0.499 ) ", Math.min ( Number.NEGATIVE_INFINITY, 0.499 ) , -Infinity ); 
+test( "Math.min ( Number.NEGATIVE_INFINITY, 0.499 ) ", Math.min ( Number.NEGATIVE_INFINITY, 0.499 ) , -Infinity );
 
 
-test( "Math.min ( Number.NEGATIVE_INFINITY, -0.5 ) ", Math.min ( Number.NEGATIVE_INFINITY, -0.5 ) , -Infinity ); 
+test( "Math.min ( Number.NEGATIVE_INFINITY, -0.5 ) ", Math.min ( Number.NEGATIVE_INFINITY, -0.5 ) , -Infinity );
 
 
-test( "Math.min ( Number.MAX_VALUE, Number.POSITIVE_INFINITY ) ", Math.min ( Number.MAX_VALUE, Number.POSITIVE_INFINITY ) , Number.MAX_VALUE ); 
+test( "Math.min ( Number.MAX_VALUE, Number.POSITIVE_INFINITY ) ", Math.min ( Number.MAX_VALUE, Number.POSITIVE_INFINITY ) , Number.MAX_VALUE );
 
 
-test( "Math.min ( Number.MAX_VALUE, Number.NEGATIVE_INFINITY ) ", Math.min ( Number.MAX_VALUE, Number.NEGATIVE_INFINITY ) , -Infinity ); 
+test( "Math.min ( Number.MAX_VALUE, Number.NEGATIVE_INFINITY ) ", Math.min ( Number.MAX_VALUE, Number.NEGATIVE_INFINITY ) , -Infinity );
 
 
-test( "Math.min ( Number.MAX_VALUE, Number.MAX_VALUE ) ", Math.min ( Number.MAX_VALUE, Number.MAX_VALUE ) , Number.MAX_VALUE ); 
+test( "Math.min ( Number.MAX_VALUE, Number.MAX_VALUE ) ", Math.min ( Number.MAX_VALUE, Number.MAX_VALUE ) , Number.MAX_VALUE );
 
 
-test( "Math.min ( Number.MAX_VALUE, Number.MIN_VALUE ) ", Math.min ( Number.MAX_VALUE, Number.MIN_VALUE ) , Number.MIN_VALUE ); 
+test( "Math.min ( Number.MAX_VALUE, Number.MIN_VALUE ) ", Math.min ( Number.MAX_VALUE, Number.MIN_VALUE ) , Number.MIN_VALUE );
 
 
-test( "Math.min ( Number.MAX_VALUE, Number.NaN ) ", Math.min ( Number.MAX_VALUE, Number.NaN ) , Number.NaN ); 
+test( "Math.min ( Number.MAX_VALUE, Number.NaN ) ", Math.min ( Number.MAX_VALUE, Number.NaN ) , Number.NaN );
 
 
-test( "Math.min ( Number.MAX_VALUE, 0 ) ", Math.min ( Number.MAX_VALUE, 0 ) , 0 ); 
+test( "Math.min ( Number.MAX_VALUE, 0 ) ", Math.min ( Number.MAX_VALUE, 0 ) , 0 );
 
 
-test( "Math.min ( Number.MAX_VALUE, -0 ) ", Math.min ( Number.MAX_VALUE, -0 ) , 0 ); 
+test( "Math.min ( Number.MAX_VALUE, -0 ) ", Math.min ( Number.MAX_VALUE, -0 ) , 0 );
 
 
-test( "Math.min ( Number.MAX_VALUE, 1 ) ", Math.min ( Number.MAX_VALUE, 1 ) , 1 ); 
+test( "Math.min ( Number.MAX_VALUE, 1 ) ", Math.min ( Number.MAX_VALUE, 1 ) , 1 );
 
 
-test( "Math.min ( Number.MAX_VALUE, 1.012 ) ", Math.min ( Number.MAX_VALUE, 1.012 ) , 1.012 ); 
+test( "Math.min ( Number.MAX_VALUE, 1.012 ) ", Math.min ( Number.MAX_VALUE, 1.012 ) , 1.012 );
 
 
-test( "Math.min ( Number.MAX_VALUE, -1.12 ) ", Math.min ( Number.MAX_VALUE, -1.12 ) , -1.12 ); 
+test( "Math.min ( Number.MAX_VALUE, -1.12 ) ", Math.min ( Number.MAX_VALUE, -1.12 ) , -1.12 );
 
 
-test( "Math.min ( Number.MAX_VALUE, 0.499 ) ", Math.min ( Number.MAX_VALUE, 0.499 ) , 0.499 ); 
+test( "Math.min ( Number.MAX_VALUE, 0.499 ) ", Math.min ( Number.MAX_VALUE, 0.499 ) , 0.499 );
 
 
-test( "Math.min ( Number.MAX_VALUE, -0.5 ) ", Math.min ( Number.MAX_VALUE, -0.5 ) , -0.5 ); 
+test( "Math.min ( Number.MAX_VALUE, -0.5 ) ", Math.min ( Number.MAX_VALUE, -0.5 ) , -0.5 );
 
 
-test( "Math.min ( Number.MIN_VALUE, Number.POSITIVE_INFINITY ) ", Math.min ( Number.MIN_VALUE, Number.POSITIVE_INFINITY ) , Number.MIN_VALUE ); 
+test( "Math.min ( Number.MIN_VALUE, Number.POSITIVE_INFINITY ) ", Math.min ( Number.MIN_VALUE, Number.POSITIVE_INFINITY ) , Number.MIN_VALUE );
 /* WAS: 5e-324 */
 
-test( "Math.min ( Number.MIN_VALUE, Number.NEGATIVE_INFINITY ) ", Math.min ( Number.MIN_VALUE, Number.NEGATIVE_INFINITY ) , -Infinity ); 
+test( "Math.min ( Number.MIN_VALUE, Number.NEGATIVE_INFINITY ) ", Math.min ( Number.MIN_VALUE, Number.NEGATIVE_INFINITY ) , -Infinity );
 
 
-test( "Math.min ( Number.MIN_VALUE, Number.MAX_VALUE ) ", Math.min ( Number.MIN_VALUE, Number.MAX_VALUE ) , Number.MIN_VALUE ); 
+test( "Math.min ( Number.MIN_VALUE, Number.MAX_VALUE ) ", Math.min ( Number.MIN_VALUE, Number.MAX_VALUE ) , Number.MIN_VALUE );
 /* WAS: 5e-324 */
 
-test( "Math.min ( Number.MIN_VALUE, Number.MIN_VALUE ) ", Math.min ( Number.MIN_VALUE, Number.MIN_VALUE ) , Number.MIN_VALUE ); 
+test( "Math.min ( Number.MIN_VALUE, Number.MIN_VALUE ) ", Math.min ( Number.MIN_VALUE, Number.MIN_VALUE ) , Number.MIN_VALUE );
 /* WAS: 5e-324 */
 
-test( "Math.min ( Number.MIN_VALUE, Number.NaN ) ", Math.min ( Number.MIN_VALUE, Number.NaN ) , Number.NaN ); 
+test( "Math.min ( Number.MIN_VALUE, Number.NaN ) ", Math.min ( Number.MIN_VALUE, Number.NaN ) , Number.NaN );
 
 
-test( "Math.min ( Number.MIN_VALUE, 0 ) ", Math.min ( Number.MIN_VALUE, 0 ) , 0 ); 
+test( "Math.min ( Number.MIN_VALUE, 0 ) ", Math.min ( Number.MIN_VALUE, 0 ) , 0 );
 
 
-test( "Math.min ( Number.MIN_VALUE, -0 ) ", Math.min ( Number.MIN_VALUE, -0 ) , 0 ); 
+test( "Math.min ( Number.MIN_VALUE, -0 ) ", Math.min ( Number.MIN_VALUE, -0 ) , 0 );
 
 
-test( "Math.min ( Number.MIN_VALUE, 1 ) ", Math.min ( Number.MIN_VALUE, 1 ) , Number.MIN_VALUE ); 
+test( "Math.min ( Number.MIN_VALUE, 1 ) ", Math.min ( Number.MIN_VALUE, 1 ) , Number.MIN_VALUE );
 /* WAS: 5e-324 */
 
-test( "Math.min ( Number.MIN_VALUE, 1.012 ) ", Math.min ( Number.MIN_VALUE, 1.012 ) , Number.MIN_VALUE ); 
+test( "Math.min ( Number.MIN_VALUE, 1.012 ) ", Math.min ( Number.MIN_VALUE, 1.012 ) , Number.MIN_VALUE );
 /* WAS: 5e-324 */
 
-test( "Math.min ( Number.MIN_VALUE, -1.12 ) ", Math.min ( Number.MIN_VALUE, -1.12 ) , -1.12 ); 
+test( "Math.min ( Number.MIN_VALUE, -1.12 ) ", Math.min ( Number.MIN_VALUE, -1.12 ) , -1.12 );
 
 
-test( "Math.min ( Number.MIN_VALUE, 0.499 ) ", Math.min ( Number.MIN_VALUE, 0.499 ) , Number.MIN_VALUE ); 
+test( "Math.min ( Number.MIN_VALUE, 0.499 ) ", Math.min ( Number.MIN_VALUE, 0.499 ) , Number.MIN_VALUE );
 /* WAS: 5e-324 */
 
-test( "Math.min ( Number.MIN_VALUE, -0.5 ) ", Math.min ( Number.MIN_VALUE, -0.5 ) , -0.5 ); 
+test( "Math.min ( Number.MIN_VALUE, -0.5 ) ", Math.min ( Number.MIN_VALUE, -0.5 ) , -0.5 );
 
 
-test( "Math.min ( Number.NaN, Number.POSITIVE_INFINITY ) ", Math.min ( Number.NaN, Number.POSITIVE_INFINITY ) , Number.NaN ); 
+test( "Math.min ( Number.NaN, Number.POSITIVE_INFINITY ) ", Math.min ( Number.NaN, Number.POSITIVE_INFINITY ) , Number.NaN );
 
 
-test( "Math.min ( Number.NaN, Number.NEGATIVE_INFINITY ) ", Math.min ( Number.NaN, Number.NEGATIVE_INFINITY ) , Number.NaN ); 
+test( "Math.min ( Number.NaN, Number.NEGATIVE_INFINITY ) ", Math.min ( Number.NaN, Number.NEGATIVE_INFINITY ) , Number.NaN );
 
 
-test( "Math.min ( Number.NaN, Number.MAX_VALUE ) ", Math.min ( Number.NaN, Number.MAX_VALUE ) , Number.NaN ); 
+test( "Math.min ( Number.NaN, Number.MAX_VALUE ) ", Math.min ( Number.NaN, Number.MAX_VALUE ) , Number.NaN );
 
 
-test( "Math.min ( Number.NaN, Number.MIN_VALUE ) ", Math.min ( Number.NaN, Number.MIN_VALUE ) , Number.NaN ); 
+test( "Math.min ( Number.NaN, Number.MIN_VALUE ) ", Math.min ( Number.NaN, Number.MIN_VALUE ) , Number.NaN );
 
 
-test( "Math.min ( Number.NaN, Number.NaN ) ", Math.min ( Number.NaN, Number.NaN ) , Number.NaN ); 
+test( "Math.min ( Number.NaN, Number.NaN ) ", Math.min ( Number.NaN, Number.NaN ) , Number.NaN );
 
 
-test( "Math.min ( Number.NaN, 0 ) ", Math.min ( Number.NaN, 0 ) , Number.NaN ); 
+test( "Math.min ( Number.NaN, 0 ) ", Math.min ( Number.NaN, 0 ) , Number.NaN );
 
 
-test( "Math.min ( Number.NaN, -0 ) ", Math.min ( Number.NaN, -0 ) , Number.NaN ); 
+test( "Math.min ( Number.NaN, -0 ) ", Math.min ( Number.NaN, -0 ) , Number.NaN );
 
 
-test( "Math.min ( Number.NaN, 1 ) ", Math.min ( Number.NaN, 1 ) , Number.NaN ); 
+test( "Math.min ( Number.NaN, 1 ) ", Math.min ( Number.NaN, 1 ) , Number.NaN );
 
 
-test( "Math.min ( Number.NaN, 1.012 ) ", Math.min ( Number.NaN, 1.012 ) , Number.NaN ); 
+test( "Math.min ( Number.NaN, 1.012 ) ", Math.min ( Number.NaN, 1.012 ) , Number.NaN );
 
 
-test( "Math.min ( Number.NaN, -1.12 ) ", Math.min ( Number.NaN, -1.12 ) , Number.NaN ); 
+test( "Math.min ( Number.NaN, -1.12 ) ", Math.min ( Number.NaN, -1.12 ) , Number.NaN );
 
 
-test( "Math.min ( Number.NaN, 0.499 ) ", Math.min ( Number.NaN, 0.499 ) , Number.NaN ); 
+test( "Math.min ( Number.NaN, 0.499 ) ", Math.min ( Number.NaN, 0.499 ) , Number.NaN );
 
 
-test( "Math.min ( Number.NaN, -0.5 ) ", Math.min ( Number.NaN, -0.5 ) , Number.NaN ); 
+test( "Math.min ( Number.NaN, -0.5 ) ", Math.min ( Number.NaN, -0.5 ) , Number.NaN );
 
 
-test( "Math.min ( 0, Number.POSITIVE_INFINITY ) ", Math.min ( 0, Number.POSITIVE_INFINITY ) , 0 ); 
+test( "Math.min ( 0, Number.POSITIVE_INFINITY ) ", Math.min ( 0, Number.POSITIVE_INFINITY ) , 0 );
 
 
-test( "Math.min ( 0, Number.NEGATIVE_INFINITY ) ", Math.min ( 0, Number.NEGATIVE_INFINITY ) , -Infinity ); 
+test( "Math.min ( 0, Number.NEGATIVE_INFINITY ) ", Math.min ( 0, Number.NEGATIVE_INFINITY ) , -Infinity );
 
 
-test( "Math.min ( 0, Number.MAX_VALUE ) ", Math.min ( 0, Number.MAX_VALUE ) , 0 ); 
+test( "Math.min ( 0, Number.MAX_VALUE ) ", Math.min ( 0, Number.MAX_VALUE ) , 0 );
 
 
-test( "Math.min ( 0, Number.MIN_VALUE ) ", Math.min ( 0, Number.MIN_VALUE ) , 0 ); 
+test( "Math.min ( 0, Number.MIN_VALUE ) ", Math.min ( 0, Number.MIN_VALUE ) , 0 );
 
 
-test( "Math.min ( 0, Number.NaN ) ", Math.min ( 0, Number.NaN ) , Number.NaN ); 
+test( "Math.min ( 0, Number.NaN ) ", Math.min ( 0, Number.NaN ) , Number.NaN );
 
 
-test( "Math.min ( 0, 0 ) ", Math.min ( 0, 0 ) , 0 ); 
+test( "Math.min ( 0, 0 ) ", Math.min ( 0, 0 ) , 0 );
 
 
-test( "Math.min ( 0, -0 ) ", Math.min ( 0, -0 ) , 0 ); 
+test( "Math.min ( 0, -0 ) ", Math.min ( 0, -0 ) , 0 );
 
 
-test( "Math.min ( 0, 1 ) ", Math.min ( 0, 1 ) , 0 ); 
+test( "Math.min ( 0, 1 ) ", Math.min ( 0, 1 ) , 0 );
 
 
-test( "Math.min ( 0, 1.012 ) ", Math.min ( 0, 1.012 ) , 0 ); 
+test( "Math.min ( 0, 1.012 ) ", Math.min ( 0, 1.012 ) , 0 );
 
 
-test( "Math.min ( 0, -1.12 ) ", Math.min ( 0, -1.12 ) , -1.12 ); 
+test( "Math.min ( 0, -1.12 ) ", Math.min ( 0, -1.12 ) , -1.12 );
 
 
-test( "Math.min ( 0, 0.499 ) ", Math.min ( 0, 0.499 ) , 0 ); 
+test( "Math.min ( 0, 0.499 ) ", Math.min ( 0, 0.499 ) , 0 );
 
 
-test( "Math.min ( 0, -0.5 ) ", Math.min ( 0, -0.5 ) , -0.5 ); 
+test( "Math.min ( 0, -0.5 ) ", Math.min ( 0, -0.5 ) , -0.5 );
 
 
-test( "Math.min ( -0, Number.POSITIVE_INFINITY ) ", Math.min ( -0, Number.POSITIVE_INFINITY ) , 0 ); 
+test( "Math.min ( -0, Number.POSITIVE_INFINITY ) ", Math.min ( -0, Number.POSITIVE_INFINITY ) , 0 );
 
 
-test( "Math.min ( -0, Number.NEGATIVE_INFINITY ) ", Math.min ( -0, Number.NEGATIVE_INFINITY ) , -Infinity ); 
+test( "Math.min ( -0, Number.NEGATIVE_INFINITY ) ", Math.min ( -0, Number.NEGATIVE_INFINITY ) , -Infinity );
 
 
-test( "Math.min ( -0, Number.MAX_VALUE ) ", Math.min ( -0, Number.MAX_VALUE ) , 0 ); 
+test( "Math.min ( -0, Number.MAX_VALUE ) ", Math.min ( -0, Number.MAX_VALUE ) , 0 );
 
 
-test( "Math.min ( -0, Number.MIN_VALUE ) ", Math.min ( -0, Number.MIN_VALUE ) , 0 ); 
+test( "Math.min ( -0, Number.MIN_VALUE ) ", Math.min ( -0, Number.MIN_VALUE ) , 0 );
 
 
-test( "Math.min ( -0, Number.NaN ) ", Math.min ( -0, Number.NaN ) , Number.NaN ); 
+test( "Math.min ( -0, Number.NaN ) ", Math.min ( -0, Number.NaN ) , Number.NaN );
 
 
-test( "Math.min ( -0, 0 ) ", Math.min ( -0, 0 ) , 0 ); 
+test( "Math.min ( -0, 0 ) ", Math.min ( -0, 0 ) , 0 );
 
 
-test( "Math.min ( -0, -0 ) ", Math.min ( -0, -0 ) , 0 ); 
+test( "Math.min ( -0, -0 ) ", Math.min ( -0, -0 ) , 0 );
 
 
-test( "Math.min ( -0, 1 ) ", Math.min ( -0, 1 ) , 0 ); 
+test( "Math.min ( -0, 1 ) ", Math.min ( -0, 1 ) , 0 );
 
 
-test( "Math.min ( -0, 1.012 ) ", Math.min ( -0, 1.012 ) , 0 ); 
+test( "Math.min ( -0, 1.012 ) ", Math.min ( -0, 1.012 ) , 0 );
 
 
-test( "Math.min ( -0, -1.12 ) ", Math.min ( -0, -1.12 ) , -1.12 ); 
+test( "Math.min ( -0, -1.12 ) ", Math.min ( -0, -1.12 ) , -1.12 );
 
 
-test( "Math.min ( -0, 0.499 ) ", Math.min ( -0, 0.499 ) , 0 ); 
+test( "Math.min ( -0, 0.499 ) ", Math.min ( -0, 0.499 ) , 0 );
 
 
-test( "Math.min ( -0, -0.5 ) ", Math.min ( -0, -0.5 ) , -0.5 ); 
+test( "Math.min ( -0, -0.5 ) ", Math.min ( -0, -0.5 ) , -0.5 );
 
 
-test( "Math.min ( 1, Number.POSITIVE_INFINITY ) ", Math.min ( 1, Number.POSITIVE_INFINITY ) , 1 ); 
+test( "Math.min ( 1, Number.POSITIVE_INFINITY ) ", Math.min ( 1, Number.POSITIVE_INFINITY ) , 1 );
 
 
-test( "Math.min ( 1, Number.NEGATIVE_INFINITY ) ", Math.min ( 1, Number.NEGATIVE_INFINITY ) , -Infinity ); 
+test( "Math.min ( 1, Number.NEGATIVE_INFINITY ) ", Math.min ( 1, Number.NEGATIVE_INFINITY ) , -Infinity );
 
 
-test( "Math.min ( 1, Number.MAX_VALUE ) ", Math.min ( 1, Number.MAX_VALUE ) , 1 ); 
+test( "Math.min ( 1, Number.MAX_VALUE ) ", Math.min ( 1, Number.MAX_VALUE ) , 1 );
 
 
-test( "Math.min ( 1, Number.MIN_VALUE ) ", Math.min ( 1, Number.MIN_VALUE ) , Number.MIN_VALUE ); 
+test( "Math.min ( 1, Number.MIN_VALUE ) ", Math.min ( 1, Number.MIN_VALUE ) , Number.MIN_VALUE );
 
 
-test( "Math.min ( 1, Number.NaN ) ", Math.min ( 1, Number.NaN ) , Number.NaN ); 
+test( "Math.min ( 1, Number.NaN ) ", Math.min ( 1, Number.NaN ) , Number.NaN );
 
 
-test( "Math.min ( 1, 0 ) ", Math.min ( 1, 0 ) , 0 ); 
+test( "Math.min ( 1, 0 ) ", Math.min ( 1, 0 ) , 0 );
 
 
-test( "Math.min ( 1, -0 ) ", Math.min ( 1, -0 ) , 0 ); 
+test( "Math.min ( 1, -0 ) ", Math.min ( 1, -0 ) , 0 );
 
 
-test( "Math.min ( 1, 1 ) ", Math.min ( 1, 1 ) , 1 ); 
+test( "Math.min ( 1, 1 ) ", Math.min ( 1, 1 ) , 1 );
 
 
-test( "Math.min ( 1, 1.012 ) ", Math.min ( 1, 1.012 ) , 1 ); 
+test( "Math.min ( 1, 1.012 ) ", Math.min ( 1, 1.012 ) , 1 );
 
 
-test( "Math.min ( 1, -1.12 ) ", Math.min ( 1, -1.12 ) , -1.12 ); 
+test( "Math.min ( 1, -1.12 ) ", Math.min ( 1, -1.12 ) , -1.12 );
 
 
-test( "Math.min ( 1, 0.499 ) ", Math.min ( 1, 0.499 ) , 0.499 ); 
+test( "Math.min ( 1, 0.499 ) ", Math.min ( 1, 0.499 ) , 0.499 );
 
 
-test( "Math.min ( 1, -0.5 ) ", Math.min ( 1, -0.5 ) , -0.5 ); 
+test( "Math.min ( 1, -0.5 ) ", Math.min ( 1, -0.5 ) , -0.5 );
 
 
-test( "Math.min ( 1.012, Number.POSITIVE_INFINITY ) ", Math.min ( 1.012, Number.POSITIVE_INFINITY ) , 1.012 ); 
+test( "Math.min ( 1.012, Number.POSITIVE_INFINITY ) ", Math.min ( 1.012, Number.POSITIVE_INFINITY ) , 1.012 );
 
 
-test( "Math.min ( 1.012, Number.NEGATIVE_INFINITY ) ", Math.min ( 1.012, Number.NEGATIVE_INFINITY ) , -Infinity ); 
+test( "Math.min ( 1.012, Number.NEGATIVE_INFINITY ) ", Math.min ( 1.012, Number.NEGATIVE_INFINITY ) , -Infinity );
 
 
-test( "Math.min ( 1.012, Number.MAX_VALUE ) ", Math.min ( 1.012, Number.MAX_VALUE ) , 1.012 ); 
+test( "Math.min ( 1.012, Number.MAX_VALUE ) ", Math.min ( 1.012, Number.MAX_VALUE ) , 1.012 );
 
 
-test( "Math.min ( 1.012, Number.MIN_VALUE ) ", Math.min ( 1.012, Number.MIN_VALUE ) , Number.MIN_VALUE ); 
+test( "Math.min ( 1.012, Number.MIN_VALUE ) ", Math.min ( 1.012, Number.MIN_VALUE ) , Number.MIN_VALUE );
 
 
-test( "Math.min ( 1.012, Number.NaN ) ", Math.min ( 1.012, Number.NaN ) , Number.NaN ); 
+test( "Math.min ( 1.012, Number.NaN ) ", Math.min ( 1.012, Number.NaN ) , Number.NaN );
 
 
-test( "Math.min ( 1.012, 0 ) ", Math.min ( 1.012, 0 ) , 0 ); 
+test( "Math.min ( 1.012, 0 ) ", Math.min ( 1.012, 0 ) , 0 );
 
 
-test( "Math.min ( 1.012, -0 ) ", Math.min ( 1.012, -0 ) , 0 ); 
+test( "Math.min ( 1.012, -0 ) ", Math.min ( 1.012, -0 ) , 0 );
 
 
-test( "Math.min ( 1.012, 1 ) ", Math.min ( 1.012, 1 ) , 1 ); 
+test( "Math.min ( 1.012, 1 ) ", Math.min ( 1.012, 1 ) , 1 );
 
 
-test( "Math.min ( 1.012, 1.012 ) ", Math.min ( 1.012, 1.012 ) , 1.012 ); 
+test( "Math.min ( 1.012, 1.012 ) ", Math.min ( 1.012, 1.012 ) , 1.012 );
 
 
-test( "Math.min ( 1.012, -1.12 ) ", Math.min ( 1.012, -1.12 ) , -1.12 ); 
+test( "Math.min ( 1.012, -1.12 ) ", Math.min ( 1.012, -1.12 ) , -1.12 );
 
 
-test( "Math.min ( 1.012, 0.499 ) ", Math.min ( 1.012, 0.499 ) , 0.499 ); 
+test( "Math.min ( 1.012, 0.499 ) ", Math.min ( 1.012, 0.499 ) , 0.499 );
 
 
-test( "Math.min ( 1.012, -0.5 ) ", Math.min ( 1.012, -0.5 ) , -0.5 ); 
+test( "Math.min ( 1.012, -0.5 ) ", Math.min ( 1.012, -0.5 ) , -0.5 );
 
 
-test( "Math.min ( -1.12, Number.POSITIVE_INFINITY ) ", Math.min ( -1.12, Number.POSITIVE_INFINITY ) , -1.12 ); 
+test( "Math.min ( -1.12, Number.POSITIVE_INFINITY ) ", Math.min ( -1.12, Number.POSITIVE_INFINITY ) , -1.12 );
 
 
-test( "Math.min ( -1.12, Number.NEGATIVE_INFINITY ) ", Math.min ( -1.12, Number.NEGATIVE_INFINITY ) , -Infinity ); 
+test( "Math.min ( -1.12, Number.NEGATIVE_INFINITY ) ", Math.min ( -1.12, Number.NEGATIVE_INFINITY ) , -Infinity );
 
 
-test( "Math.min ( -1.12, Number.MAX_VALUE ) ", Math.min ( -1.12, Number.MAX_VALUE ) , -1.12 ); 
+test( "Math.min ( -1.12, Number.MAX_VALUE ) ", Math.min ( -1.12, Number.MAX_VALUE ) , -1.12 );
 
 
-test( "Math.min ( -1.12, Number.MIN_VALUE ) ", Math.min ( -1.12, Number.MIN_VALUE ) , -1.12 ); 
+test( "Math.min ( -1.12, Number.MIN_VALUE ) ", Math.min ( -1.12, Number.MIN_VALUE ) , -1.12 );
 
 
-test( "Math.min ( -1.12, Number.NaN ) ", Math.min ( -1.12, Number.NaN ) , Number.NaN ); 
+test( "Math.min ( -1.12, Number.NaN ) ", Math.min ( -1.12, Number.NaN ) , Number.NaN );
 
 
-test( "Math.min ( -1.12, 0 ) ", Math.min ( -1.12, 0 ) , -1.12 ); 
+test( "Math.min ( -1.12, 0 ) ", Math.min ( -1.12, 0 ) , -1.12 );
 
 
-test( "Math.min ( -1.12, -0 ) ", Math.min ( -1.12, -0 ) , -1.12 ); 
+test( "Math.min ( -1.12, -0 ) ", Math.min ( -1.12, -0 ) , -1.12 );
 
 
-test( "Math.min ( -1.12, 1 ) ", Math.min ( -1.12, 1 ) , -1.12 ); 
+test( "Math.min ( -1.12, 1 ) ", Math.min ( -1.12, 1 ) , -1.12 );
 
 
-test( "Math.min ( -1.12, 1.012 ) ", Math.min ( -1.12, 1.012 ) , -1.12 ); 
+test( "Math.min ( -1.12, 1.012 ) ", Math.min ( -1.12, 1.012 ) , -1.12 );
 
 
-test( "Math.min ( -1.12, -1.12 ) ", Math.min ( -1.12, -1.12 ) , -1.12 ); 
+test( "Math.min ( -1.12, -1.12 ) ", Math.min ( -1.12, -1.12 ) , -1.12 );
 
 
-test( "Math.min ( -1.12, 0.499 ) ", Math.min ( -1.12, 0.499 ) , -1.12 ); 
+test( "Math.min ( -1.12, 0.499 ) ", Math.min ( -1.12, 0.499 ) , -1.12 );
 
 
-test( "Math.min ( -1.12, -0.5 ) ", Math.min ( -1.12, -0.5 ) , -1.12 ); 
+test( "Math.min ( -1.12, -0.5 ) ", Math.min ( -1.12, -0.5 ) , -1.12 );
 
 
-test( "Math.min ( 0.499, Number.POSITIVE_INFINITY ) ", Math.min ( 0.499, Number.POSITIVE_INFINITY ) , 0.499 ); 
+test( "Math.min ( 0.499, Number.POSITIVE_INFINITY ) ", Math.min ( 0.499, Number.POSITIVE_INFINITY ) , 0.499 );
 
 
-test( "Math.min ( 0.499, Number.NEGATIVE_INFINITY ) ", Math.min ( 0.499, Number.NEGATIVE_INFINITY ) , -Infinity ); 
+test( "Math.min ( 0.499, Number.NEGATIVE_INFINITY ) ", Math.min ( 0.499, Number.NEGATIVE_INFINITY ) , -Infinity );
 
 
-test( "Math.min ( 0.499, Number.MAX_VALUE ) ", Math.min ( 0.499, Number.MAX_VALUE ) , 0.499 ); 
+test( "Math.min ( 0.499, Number.MAX_VALUE ) ", Math.min ( 0.499, Number.MAX_VALUE ) , 0.499 );
 
 
-test( "Math.min ( 0.499, Number.MIN_VALUE ) ", Math.min ( 0.499, Number.MIN_VALUE ) , Number.MIN_VALUE ); 
+test( "Math.min ( 0.499, Number.MIN_VALUE ) ", Math.min ( 0.499, Number.MIN_VALUE ) , Number.MIN_VALUE );
 
 
-test( "Math.min ( 0.499, Number.NaN ) ", Math.min ( 0.499, Number.NaN ) , Number.NaN ); 
+test( "Math.min ( 0.499, Number.NaN ) ", Math.min ( 0.499, Number.NaN ) , Number.NaN );
 
 
-test( "Math.min ( 0.499, 0 ) ", Math.min ( 0.499, 0 ) , 0 ); 
+test( "Math.min ( 0.499, 0 ) ", Math.min ( 0.499, 0 ) , 0 );
 
 
-test( "Math.min ( 0.499, -0 ) ", Math.min ( 0.499, -0 ) , 0 ); 
+test( "Math.min ( 0.499, -0 ) ", Math.min ( 0.499, -0 ) , 0 );
 
 
-test( "Math.min ( 0.499, 1 ) ", Math.min ( 0.499, 1 ) , 0.499 ); 
+test( "Math.min ( 0.499, 1 ) ", Math.min ( 0.499, 1 ) , 0.499 );
 
 
-test( "Math.min ( 0.499, 1.012 ) ", Math.min ( 0.499, 1.012 ) , 0.499 ); 
+test( "Math.min ( 0.499, 1.012 ) ", Math.min ( 0.499, 1.012 ) , 0.499 );
 
 
-test( "Math.min ( 0.499, -1.12 ) ", Math.min ( 0.499, -1.12 ) , -1.12 ); 
+test( "Math.min ( 0.499, -1.12 ) ", Math.min ( 0.499, -1.12 ) , -1.12 );
 
 
-test( "Math.min ( 0.499, 0.499 ) ", Math.min ( 0.499, 0.499 ) , 0.499 ); 
+test( "Math.min ( 0.499, 0.499 ) ", Math.min ( 0.499, 0.499 ) , 0.499 );
 
 
-test( "Math.min ( 0.499, -0.5 ) ", Math.min ( 0.499, -0.5 ) , -0.5 ); 
+test( "Math.min ( 0.499, -0.5 ) ", Math.min ( 0.499, -0.5 ) , -0.5 );
 
 
-test( "Math.min ( -0.5, Number.POSITIVE_INFINITY ) ", Math.min ( -0.5, Number.POSITIVE_INFINITY ) , -0.5 ); 
+test( "Math.min ( -0.5, Number.POSITIVE_INFINITY ) ", Math.min ( -0.5, Number.POSITIVE_INFINITY ) , -0.5 );
 
 
-test( "Math.min ( -0.5, Number.NEGATIVE_INFINITY ) ", Math.min ( -0.5, Number.NEGATIVE_INFINITY ) , -Infinity ); 
+test( "Math.min ( -0.5, Number.NEGATIVE_INFINITY ) ", Math.min ( -0.5, Number.NEGATIVE_INFINITY ) , -Infinity );
 
 
-test( "Math.min ( -0.5, Number.MAX_VALUE ) ", Math.min ( -0.5, Number.MAX_VALUE ) , -0.5 ); 
+test( "Math.min ( -0.5, Number.MAX_VALUE ) ", Math.min ( -0.5, Number.MAX_VALUE ) , -0.5 );
 
 
-test( "Math.min ( -0.5, Number.MIN_VALUE ) ", Math.min ( -0.5, Number.MIN_VALUE ) , -0.5 ); 
+test( "Math.min ( -0.5, Number.MIN_VALUE ) ", Math.min ( -0.5, Number.MIN_VALUE ) , -0.5 );
 
 
-test( "Math.min ( -0.5, Number.NaN ) ", Math.min ( -0.5, Number.NaN ) , Number.NaN ); 
+test( "Math.min ( -0.5, Number.NaN ) ", Math.min ( -0.5, Number.NaN ) , Number.NaN );
 
 
-test( "Math.min ( -0.5, 0 ) ", Math.min ( -0.5, 0 ) , -0.5 ); 
+test( "Math.min ( -0.5, 0 ) ", Math.min ( -0.5, 0 ) , -0.5 );
 
 
-test( "Math.min ( -0.5, -0 ) ", Math.min ( -0.5, -0 ) , -0.5 ); 
+test( "Math.min ( -0.5, -0 ) ", Math.min ( -0.5, -0 ) , -0.5 );
 
 
-test( "Math.min ( -0.5, 1 ) ", Math.min ( -0.5, 1 ) , -0.5 ); 
+test( "Math.min ( -0.5, 1 ) ", Math.min ( -0.5, 1 ) , -0.5 );
 
 
-test( "Math.min ( -0.5, 1.012 ) ", Math.min ( -0.5, 1.012 ) , -0.5 ); 
+test( "Math.min ( -0.5, 1.012 ) ", Math.min ( -0.5, 1.012 ) , -0.5 );
 
 
-test( "Math.min ( -0.5, -1.12 ) ", Math.min ( -0.5, -1.12 ) , -1.12 ); 
+test( "Math.min ( -0.5, -1.12 ) ", Math.min ( -0.5, -1.12 ) , -1.12 );
 
 
-test( "Math.min ( -0.5, 0.499 ) ", Math.min ( -0.5, 0.499 ) , -0.5 ); 
+test( "Math.min ( -0.5, 0.499 ) ", Math.min ( -0.5, 0.499 ) , -0.5 );
 
 
-test( "Math.min ( -0.5, -0.5 ) ", Math.min ( -0.5, -0.5 ) , -0.5 ); 
+test( "Math.min ( -0.5, -0.5 ) ", Math.min ( -0.5, -0.5 ) , -0.5 );
 
 
-test( "Math.pow ( Number.POSITIVE_INFINITY, Number.POSITIVE_INFINITY ) ", Math.pow ( Number.POSITIVE_INFINITY, Number.POSITIVE_INFINITY ) , Infinity ); 
+test( "Math.pow ( Number.POSITIVE_INFINITY, Number.POSITIVE_INFINITY ) ", Math.pow ( Number.POSITIVE_INFINITY, Number.POSITIVE_INFINITY ) , Infinity );
 
 
-test( "Math.pow ( Number.POSITIVE_INFINITY, Number.NEGATIVE_INFINITY ) ", Math.pow ( Number.POSITIVE_INFINITY, Number.NEGATIVE_INFINITY ) , 0 ); 
+test( "Math.pow ( Number.POSITIVE_INFINITY, Number.NEGATIVE_INFINITY ) ", Math.pow ( Number.POSITIVE_INFINITY, Number.NEGATIVE_INFINITY ) , 0 );
 
 
-test( "Math.pow ( Number.POSITIVE_INFINITY, Number.MAX_VALUE ) ", Math.pow ( Number.POSITIVE_INFINITY, Number.MAX_VALUE ) , Infinity ); 
+test( "Math.pow ( Number.POSITIVE_INFINITY, Number.MAX_VALUE ) ", Math.pow ( Number.POSITIVE_INFINITY, Number.MAX_VALUE ) , Infinity );
 
 
-test( "Math.pow ( Number.POSITIVE_INFINITY, Number.MIN_VALUE ) ", Math.pow ( Number.POSITIVE_INFINITY, Number.MIN_VALUE ) , Infinity ); 
+test( "Math.pow ( Number.POSITIVE_INFINITY, Number.MIN_VALUE ) ", Math.pow ( Number.POSITIVE_INFINITY, Number.MIN_VALUE ) , Infinity );
 
 
-test( "Math.pow ( Number.POSITIVE_INFINITY, Number.NaN ) ", Math.pow ( Number.POSITIVE_INFINITY, Number.NaN ) , Number.NaN ); 
+test( "Math.pow ( Number.POSITIVE_INFINITY, Number.NaN ) ", Math.pow ( Number.POSITIVE_INFINITY, Number.NaN ) , Number.NaN );
 
 
-test( "Math.pow ( Number.POSITIVE_INFINITY, 0 ) ", Math.pow ( Number.POSITIVE_INFINITY, 0 ) , 1 ); 
+test( "Math.pow ( Number.POSITIVE_INFINITY, 0 ) ", Math.pow ( Number.POSITIVE_INFINITY, 0 ) , 1 );
 
 
-test( "Math.pow ( Number.POSITIVE_INFINITY, -0 ) ", Math.pow ( Number.POSITIVE_INFINITY, -0 ) , 1 ); 
+test( "Math.pow ( Number.POSITIVE_INFINITY, -0 ) ", Math.pow ( Number.POSITIVE_INFINITY, -0 ) , 1 );
 
 
-test( "Math.pow ( Number.POSITIVE_INFINITY, 1 ) ", Math.pow ( Number.POSITIVE_INFINITY, 1 ) , Infinity ); 
+test( "Math.pow ( Number.POSITIVE_INFINITY, 1 ) ", Math.pow ( Number.POSITIVE_INFINITY, 1 ) , Infinity );
 
 
-test( "Math.pow ( Number.POSITIVE_INFINITY, 1.012 ) ", Math.pow ( Number.POSITIVE_INFINITY, 1.012 ) , Infinity ); 
+test( "Math.pow ( Number.POSITIVE_INFINITY, 1.012 ) ", Math.pow ( Number.POSITIVE_INFINITY, 1.012 ) , Infinity );
 
 
-test( "Math.pow ( Number.POSITIVE_INFINITY, -1.12 ) ", Math.pow ( Number.POSITIVE_INFINITY, -1.12 ) , 0 ); 
+test( "Math.pow ( Number.POSITIVE_INFINITY, -1.12 ) ", Math.pow ( Number.POSITIVE_INFINITY, -1.12 ) , 0 );
 
 
-test( "Math.pow ( Number.POSITIVE_INFINITY, 0.499 ) ", Math.pow ( Number.POSITIVE_INFINITY, 0.499 ) , Infinity ); 
+test( "Math.pow ( Number.POSITIVE_INFINITY, 0.499 ) ", Math.pow ( Number.POSITIVE_INFINITY, 0.499 ) , Infinity );
 
 
-test( "Math.pow ( Number.POSITIVE_INFINITY, -0.5 ) ", Math.pow ( Number.POSITIVE_INFINITY, -0.5 ) , 0 ); 
+test( "Math.pow ( Number.POSITIVE_INFINITY, -0.5 ) ", Math.pow ( Number.POSITIVE_INFINITY, -0.5 ) , 0 );
 
 
-test( "Math.pow ( Number.NEGATIVE_INFINITY, Number.POSITIVE_INFINITY ) ", Math.pow ( Number.NEGATIVE_INFINITY, Number.POSITIVE_INFINITY ) , Infinity ); 
+test( "Math.pow ( Number.NEGATIVE_INFINITY, Number.POSITIVE_INFINITY ) ", Math.pow ( Number.NEGATIVE_INFINITY, Number.POSITIVE_INFINITY ) , Infinity );
 
 
-test( "Math.pow ( Number.NEGATIVE_INFINITY, Number.NEGATIVE_INFINITY ) ", Math.pow ( Number.NEGATIVE_INFINITY, Number.NEGATIVE_INFINITY ) , 0 ); 
+test( "Math.pow ( Number.NEGATIVE_INFINITY, Number.NEGATIVE_INFINITY ) ", Math.pow ( Number.NEGATIVE_INFINITY, Number.NEGATIVE_INFINITY ) , 0 );
 
 
-test( "Math.pow ( Number.NEGATIVE_INFINITY, Number.MAX_VALUE ) ", Math.pow ( Number.NEGATIVE_INFINITY, Number.MAX_VALUE ) , Infinity ); 
+test( "Math.pow ( Number.NEGATIVE_INFINITY, Number.MAX_VALUE ) ", Math.pow ( Number.NEGATIVE_INFINITY, Number.MAX_VALUE ) , Infinity );
 
 
-test( "Math.pow ( Number.NEGATIVE_INFINITY, Number.MIN_VALUE ) ", Math.pow ( Number.NEGATIVE_INFINITY, Number.MIN_VALUE ) , Infinity ); 
+test( "Math.pow ( Number.NEGATIVE_INFINITY, Number.MIN_VALUE ) ", Math.pow ( Number.NEGATIVE_INFINITY, Number.MIN_VALUE ) , Infinity );
 
 
-test( "Math.pow ( Number.NEGATIVE_INFINITY, Number.NaN ) ", Math.pow ( Number.NEGATIVE_INFINITY, Number.NaN ) , Number.NaN ); 
+test( "Math.pow ( Number.NEGATIVE_INFINITY, Number.NaN ) ", Math.pow ( Number.NEGATIVE_INFINITY, Number.NaN ) , Number.NaN );
 
 
-test( "Math.pow ( Number.NEGATIVE_INFINITY, 0 ) ", Math.pow ( Number.NEGATIVE_INFINITY, 0 ) , 1 ); 
+test( "Math.pow ( Number.NEGATIVE_INFINITY, 0 ) ", Math.pow ( Number.NEGATIVE_INFINITY, 0 ) , 1 );
 
 
-test( "Math.pow ( Number.NEGATIVE_INFINITY, -0 ) ", Math.pow ( Number.NEGATIVE_INFINITY, -0 ) , 1 ); 
+test( "Math.pow ( Number.NEGATIVE_INFINITY, -0 ) ", Math.pow ( Number.NEGATIVE_INFINITY, -0 ) , 1 );
 
 
-test( "Math.pow ( Number.NEGATIVE_INFINITY, 1 ) ", Math.pow ( Number.NEGATIVE_INFINITY, 1 ) , -Infinity ); 
+test( "Math.pow ( Number.NEGATIVE_INFINITY, 1 ) ", Math.pow ( Number.NEGATIVE_INFINITY, 1 ) , -Infinity );
 
 
-test( "Math.pow ( Number.NEGATIVE_INFINITY, 1.012 ) ", Math.pow ( Number.NEGATIVE_INFINITY, 1.012 ) , Infinity ); 
+test( "Math.pow ( Number.NEGATIVE_INFINITY, 1.012 ) ", Math.pow ( Number.NEGATIVE_INFINITY, 1.012 ) , Infinity );
 
 
-test( "Math.pow ( Number.NEGATIVE_INFINITY, -1.12 ) ", Math.pow ( Number.NEGATIVE_INFINITY, -1.12 ) , 0 ); 
+test( "Math.pow ( Number.NEGATIVE_INFINITY, -1.12 ) ", Math.pow ( Number.NEGATIVE_INFINITY, -1.12 ) , 0 );
 
 
-test( "Math.pow ( Number.NEGATIVE_INFINITY, 0.499 ) ", Math.pow ( Number.NEGATIVE_INFINITY, 0.499 ) , Infinity ); 
+test( "Math.pow ( Number.NEGATIVE_INFINITY, 0.499 ) ", Math.pow ( Number.NEGATIVE_INFINITY, 0.499 ) , Infinity );
 
 
-test( "Math.pow ( Number.NEGATIVE_INFINITY, -0.5 ) ", Math.pow ( Number.NEGATIVE_INFINITY, -0.5 ) , 0 ); 
+test( "Math.pow ( Number.NEGATIVE_INFINITY, -0.5 ) ", Math.pow ( Number.NEGATIVE_INFINITY, -0.5 ) , 0 );
 
 
-test( "Math.pow ( Number.MAX_VALUE, Number.POSITIVE_INFINITY ) ", Math.pow ( Number.MAX_VALUE, Number.POSITIVE_INFINITY ) , Infinity ); 
+test( "Math.pow ( Number.MAX_VALUE, Number.POSITIVE_INFINITY ) ", Math.pow ( Number.MAX_VALUE, Number.POSITIVE_INFINITY ) , Infinity );
 
 
-test( "Math.pow ( Number.MAX_VALUE, Number.NEGATIVE_INFINITY ) ", Math.pow ( Number.MAX_VALUE, Number.NEGATIVE_INFINITY ) , 0 ); 
+test( "Math.pow ( Number.MAX_VALUE, Number.NEGATIVE_INFINITY ) ", Math.pow ( Number.MAX_VALUE, Number.NEGATIVE_INFINITY ) , 0 );
 
 
-test( "Math.pow ( Number.MAX_VALUE, Number.MAX_VALUE ) ", Math.pow ( Number.MAX_VALUE, Number.MAX_VALUE ) , Infinity ); 
+test( "Math.pow ( Number.MAX_VALUE, Number.MAX_VALUE ) ", Math.pow ( Number.MAX_VALUE, Number.MAX_VALUE ) , Infinity );
 
 
-test( "Math.pow ( Number.MAX_VALUE, Number.MIN_VALUE ) ", Math.pow ( Number.MAX_VALUE, Number.MIN_VALUE ) , 1 ); 
+test( "Math.pow ( Number.MAX_VALUE, Number.MIN_VALUE ) ", Math.pow ( Number.MAX_VALUE, Number.MIN_VALUE ) , 1 );
 
 
-test( "Math.pow ( Number.MAX_VALUE, Number.NaN ) ", Math.pow ( Number.MAX_VALUE, Number.NaN ) , Number.NaN ); 
+test( "Math.pow ( Number.MAX_VALUE, Number.NaN ) ", Math.pow ( Number.MAX_VALUE, Number.NaN ) , Number.NaN );
 
 
-test( "Math.pow ( Number.MAX_VALUE, 0 ) ", Math.pow ( Number.MAX_VALUE, 0 ) , 1 ); 
+test( "Math.pow ( Number.MAX_VALUE, 0 ) ", Math.pow ( Number.MAX_VALUE, 0 ) , 1 );
 
 
-test( "Math.pow ( Number.MAX_VALUE, -0 ) ", Math.pow ( Number.MAX_VALUE, -0 ) , 1 ); 
+test( "Math.pow ( Number.MAX_VALUE, -0 ) ", Math.pow ( Number.MAX_VALUE, -0 ) , 1 );
 
 
-test( "Math.pow ( Number.MAX_VALUE, 1 ) ", Math.pow ( Number.MAX_VALUE, 1 ) , Number.MAX_VALUE ); 
+test( "Math.pow ( Number.MAX_VALUE, 1 ) ", Math.pow ( Number.MAX_VALUE, 1 ) , Number.MAX_VALUE );
 
 
-test( "Math.pow ( Number.MAX_VALUE, 1.012 ) ", Math.pow ( Number.MAX_VALUE, 1.012 ) , Infinity ); 
+test( "Math.pow ( Number.MAX_VALUE, 1.012 ) ", Math.pow ( Number.MAX_VALUE, 1.012 ) , Infinity );
 
 
-test( "Math.pow ( Number.MAX_VALUE, -1.12 ) ", Math.pow ( Number.MAX_VALUE, -1.12 ) , 0 ); 
+test( "Math.pow ( Number.MAX_VALUE, -1.12 ) ", Math.pow ( Number.MAX_VALUE, -1.12 ) , 0 );
 
 
-teste( "Math.pow ( Number.MAX_VALUE, 0.499 ) ", Math.pow ( Number.MAX_VALUE, 0.499 ) , 6.593303453622057e+153 ); 
+teste( "Math.pow ( Number.MAX_VALUE, 0.499 ) ", Math.pow ( Number.MAX_VALUE, 0.499 ) , 6.593303453622057e+153 );
 
 
-teste( "Math.pow ( Number.MAX_VALUE, -0.5 ) ", Math.pow ( Number.MAX_VALUE, -0.5 ) , 7.458340731200207e-155 ); 
+teste( "Math.pow ( Number.MAX_VALUE, -0.5 ) ", Math.pow ( Number.MAX_VALUE, -0.5 ) , 7.458340731200207e-155 );
 
 
-test( "Math.pow ( Number.MIN_VALUE, Number.POSITIVE_INFINITY ) ", Math.pow ( Number.MIN_VALUE, Number.POSITIVE_INFINITY ) , 0 ); 
+test( "Math.pow ( Number.MIN_VALUE, Number.POSITIVE_INFINITY ) ", Math.pow ( Number.MIN_VALUE, Number.POSITIVE_INFINITY ) , 0 );
 
 
-test( "Math.pow ( Number.MIN_VALUE, Number.NEGATIVE_INFINITY ) ", Math.pow ( Number.MIN_VALUE, Number.NEGATIVE_INFINITY ) , Infinity ); 
+test( "Math.pow ( Number.MIN_VALUE, Number.NEGATIVE_INFINITY ) ", Math.pow ( Number.MIN_VALUE, Number.NEGATIVE_INFINITY ) , Infinity );
 
 
-test( "Math.pow ( Number.MIN_VALUE, Number.MAX_VALUE ) ", Math.pow ( Number.MIN_VALUE, Number.MAX_VALUE ) , 0 ); 
+test( "Math.pow ( Number.MIN_VALUE, Number.MAX_VALUE ) ", Math.pow ( Number.MIN_VALUE, Number.MAX_VALUE ) , 0 );
 
 
-test( "Math.pow ( Number.MIN_VALUE, Number.MIN_VALUE ) ", Math.pow ( Number.MIN_VALUE, Number.MIN_VALUE ) , 1 ); 
+test( "Math.pow ( Number.MIN_VALUE, Number.MIN_VALUE ) ", Math.pow ( Number.MIN_VALUE, Number.MIN_VALUE ) , 1 );
 
 
-test( "Math.pow ( Number.MIN_VALUE, Number.NaN ) ", Math.pow ( Number.MIN_VALUE, Number.NaN ) , Number.NaN ); 
+test( "Math.pow ( Number.MIN_VALUE, Number.NaN ) ", Math.pow ( Number.MIN_VALUE, Number.NaN ) , Number.NaN );
 
 
-test( "Math.pow ( Number.MIN_VALUE, 0 ) ", Math.pow ( Number.MIN_VALUE, 0 ) , 1 ); 
+test( "Math.pow ( Number.MIN_VALUE, 0 ) ", Math.pow ( Number.MIN_VALUE, 0 ) , 1 );
 
 
-test( "Math.pow ( Number.MIN_VALUE, -0 ) ", Math.pow ( Number.MIN_VALUE, -0 ) , 1 ); 
+test( "Math.pow ( Number.MIN_VALUE, -0 ) ", Math.pow ( Number.MIN_VALUE, -0 ) , 1 );
 
 
-test( "Math.pow ( Number.MIN_VALUE, 1 ) ", Math.pow ( Number.MIN_VALUE, 1 ) , Number.MIN_VALUE ); 
+test( "Math.pow ( Number.MIN_VALUE, 1 ) ", Math.pow ( Number.MIN_VALUE, 1 ) , Number.MIN_VALUE );
 /* WAS: 5e-324 */
 
-test( "Math.pow ( Number.MIN_VALUE, 1.012 ) ", Math.pow ( Number.MIN_VALUE, 1.012 ) , 0 ); 
+test( "Math.pow ( Number.MIN_VALUE, 1.012 ) ", Math.pow ( Number.MIN_VALUE, 1.012 ) , 0 );
 
 
-test( "Math.pow ( Number.MIN_VALUE, -1.12 ) ", Math.pow ( Number.MIN_VALUE, -1.12 ) , Infinity ); 
+test( "Math.pow ( Number.MIN_VALUE, -1.12 ) ", Math.pow ( Number.MIN_VALUE, -1.12 ) , Infinity );
 
 
-teste( "Math.pow ( Number.MIN_VALUE, 0.499 ) ", Math.pow ( Number.MIN_VALUE, 0.499 ) , 4.679490218221973e-162 ); 
+teste( "Math.pow ( Number.MIN_VALUE, 0.499 ) ", Math.pow ( Number.MIN_VALUE, 0.499 ) , 4.679490218221973e-162 );
 
 
-teste( "Math.pow ( Number.MIN_VALUE, -0.5 ) ", Math.pow ( Number.MIN_VALUE, -0.5 ) , 4.4989137945431965e+161 ); 
+teste( "Math.pow ( Number.MIN_VALUE, -0.5 ) ", Math.pow ( Number.MIN_VALUE, -0.5 ) , 4.4989137945431965e+161 );
 
 
-test( "Math.pow ( Number.NaN, Number.POSITIVE_INFINITY ) ", Math.pow ( Number.NaN, Number.POSITIVE_INFINITY ) , Number.NaN ); 
+test( "Math.pow ( Number.NaN, Number.POSITIVE_INFINITY ) ", Math.pow ( Number.NaN, Number.POSITIVE_INFINITY ) , Number.NaN );
 
 
-test( "Math.pow ( Number.NaN, Number.NEGATIVE_INFINITY ) ", Math.pow ( Number.NaN, Number.NEGATIVE_INFINITY ) , Number.NaN ); 
+test( "Math.pow ( Number.NaN, Number.NEGATIVE_INFINITY ) ", Math.pow ( Number.NaN, Number.NEGATIVE_INFINITY ) , Number.NaN );
 
 
-test( "Math.pow ( Number.NaN, Number.MAX_VALUE ) ", Math.pow ( Number.NaN, Number.MAX_VALUE ) , Number.NaN ); 
+test( "Math.pow ( Number.NaN, Number.MAX_VALUE ) ", Math.pow ( Number.NaN, Number.MAX_VALUE ) , Number.NaN );
 
 
-test( "Math.pow ( Number.NaN, Number.MIN_VALUE ) ", Math.pow ( Number.NaN, Number.MIN_VALUE ) , Number.NaN ); 
+test( "Math.pow ( Number.NaN, Number.MIN_VALUE ) ", Math.pow ( Number.NaN, Number.MIN_VALUE ) , Number.NaN );
 
 
-test( "Math.pow ( Number.NaN, Number.NaN ) ", Math.pow ( Number.NaN, Number.NaN ) , Number.NaN ); 
+test( "Math.pow ( Number.NaN, Number.NaN ) ", Math.pow ( Number.NaN, Number.NaN ) , Number.NaN );
 
 
-test( "Math.pow ( Number.NaN, 0 ) ", Math.pow ( Number.NaN, 0 ) , 1 ); 
+test( "Math.pow ( Number.NaN, 0 ) ", Math.pow ( Number.NaN, 0 ) , 1 );
 /* ECMA: If y is +0, the result is 1, even if x is NaN. */
 
-test( "Math.pow ( Number.NaN, -0 ) ", Math.pow ( Number.NaN, -0 ) , 1 ); 
+test( "Math.pow ( Number.NaN, -0 ) ", Math.pow ( Number.NaN, -0 ) , 1 );
 /* ECMA: If y is -0, the result is 1, even if x is NaN. */
 
 
-test( "Math.pow ( Number.NaN, 1 ) ", Math.pow ( Number.NaN, 1 ) , Number.NaN ); 
+test( "Math.pow ( Number.NaN, 1 ) ", Math.pow ( Number.NaN, 1 ) , Number.NaN );
 
 
-test( "Math.pow ( Number.NaN, 1.012 ) ", Math.pow ( Number.NaN, 1.012 ) , Number.NaN ); 
+test( "Math.pow ( Number.NaN, 1.012 ) ", Math.pow ( Number.NaN, 1.012 ) , Number.NaN );
 
 
-test( "Math.pow ( Number.NaN, -1.12 ) ", Math.pow ( Number.NaN, -1.12 ) , Number.NaN ); 
+test( "Math.pow ( Number.NaN, -1.12 ) ", Math.pow ( Number.NaN, -1.12 ) , Number.NaN );
 
 
-test( "Math.pow ( Number.NaN, 0.499 ) ", Math.pow ( Number.NaN, 0.499 ) , Number.NaN ); 
+test( "Math.pow ( Number.NaN, 0.499 ) ", Math.pow ( Number.NaN, 0.499 ) , Number.NaN );
 
 
-test( "Math.pow ( Number.NaN, -0.5 ) ", Math.pow ( Number.NaN, -0.5 ) , Number.NaN ); 
+test( "Math.pow ( Number.NaN, -0.5 ) ", Math.pow ( Number.NaN, -0.5 ) , Number.NaN );
 
 
-test( "Math.pow ( 0, Number.POSITIVE_INFINITY ) ", Math.pow ( 0, Number.POSITIVE_INFINITY ) , 0 ); 
+test( "Math.pow ( 0, Number.POSITIVE_INFINITY ) ", Math.pow ( 0, Number.POSITIVE_INFINITY ) , 0 );
 
 
-test( "Math.pow ( 0, Number.NEGATIVE_INFINITY ) ", Math.pow ( 0, Number.NEGATIVE_INFINITY ) , Infinity ); 
+test( "Math.pow ( 0, Number.NEGATIVE_INFINITY ) ", Math.pow ( 0, Number.NEGATIVE_INFINITY ) , Infinity );
 
 
-test( "Math.pow ( 0, Number.MAX_VALUE ) ", Math.pow ( 0, Number.MAX_VALUE ) , 0 ); 
+test( "Math.pow ( 0, Number.MAX_VALUE ) ", Math.pow ( 0, Number.MAX_VALUE ) , 0 );
 
 
-test( "Math.pow ( 0, Number.MIN_VALUE ) ", Math.pow ( 0, Number.MIN_VALUE ) , 0 ); 
+test( "Math.pow ( 0, Number.MIN_VALUE ) ", Math.pow ( 0, Number.MIN_VALUE ) , 0 );
 
 
-test( "Math.pow ( 0, Number.NaN ) ", Math.pow ( 0, Number.NaN ) , Number.NaN ); 
+test( "Math.pow ( 0, Number.NaN ) ", Math.pow ( 0, Number.NaN ) , Number.NaN );
 
 
-test( "Math.pow ( 0, 0 ) ", Math.pow ( 0, 0 ) , 1 ); 
+test( "Math.pow ( 0, 0 ) ", Math.pow ( 0, 0 ) , 1 );
 
 
-test( "Math.pow ( 0, -0 ) ", Math.pow ( 0, -0 ) , 1 ); 
+test( "Math.pow ( 0, -0 ) ", Math.pow ( 0, -0 ) , 1 );
 
 
-test( "Math.pow ( 0, 1 ) ", Math.pow ( 0, 1 ) , 0 ); 
+test( "Math.pow ( 0, 1 ) ", Math.pow ( 0, 1 ) , 0 );
 
 
-test( "Math.pow ( 0, 1.012 ) ", Math.pow ( 0, 1.012 ) , 0 ); 
+test( "Math.pow ( 0, 1.012 ) ", Math.pow ( 0, 1.012 ) , 0 );
 
 
-test( "Math.pow ( 0, -1.12 ) ", Math.pow ( 0, -1.12 ) , Infinity ); 
+test( "Math.pow ( 0, -1.12 ) ", Math.pow ( 0, -1.12 ) , Infinity );
 
 
-test( "Math.pow ( 0, 0.499 ) ", Math.pow ( 0, 0.499 ) , 0 ); 
+test( "Math.pow ( 0, 0.499 ) ", Math.pow ( 0, 0.499 ) , 0 );
 
 
-test( "Math.pow ( 0, -0.5 ) ", Math.pow ( 0, -0.5 ) , Infinity ); 
+test( "Math.pow ( 0, -0.5 ) ", Math.pow ( 0, -0.5 ) , Infinity );
 
 
-test( "Math.pow ( -0, Number.POSITIVE_INFINITY ) ", Math.pow ( -0, Number.POSITIVE_INFINITY ) , 0 ); 
+test( "Math.pow ( -0, Number.POSITIVE_INFINITY ) ", Math.pow ( -0, Number.POSITIVE_INFINITY ) , 0 );
 
 
-test( "Math.pow ( -0, Number.NEGATIVE_INFINITY ) ", Math.pow ( -0, Number.NEGATIVE_INFINITY ) , Infinity ); 
+test( "Math.pow ( -0, Number.NEGATIVE_INFINITY ) ", Math.pow ( -0, Number.NEGATIVE_INFINITY ) , Infinity );
 
 
-test( "Math.pow ( -0, Number.MAX_VALUE ) ", Math.pow ( -0, Number.MAX_VALUE ) , 0 ); 
+test( "Math.pow ( -0, Number.MAX_VALUE ) ", Math.pow ( -0, Number.MAX_VALUE ) , 0 );
 
 
-test( "Math.pow ( -0, Number.MIN_VALUE ) ", Math.pow ( -0, Number.MIN_VALUE ) , 0 ); 
+test( "Math.pow ( -0, Number.MIN_VALUE ) ", Math.pow ( -0, Number.MIN_VALUE ) , 0 );
 
 
-test( "Math.pow ( -0, Number.NaN ) ", Math.pow ( -0, Number.NaN ) , Number.NaN ); 
+test( "Math.pow ( -0, Number.NaN ) ", Math.pow ( -0, Number.NaN ) , Number.NaN );
 
 
-test( "Math.pow ( -0, 0 ) ", Math.pow ( -0, 0 ) , 1 ); 
+test( "Math.pow ( -0, 0 ) ", Math.pow ( -0, 0 ) , 1 );
 
 
-test( "Math.pow ( -0, -0 ) ", Math.pow ( -0, -0 ) , 1 ); 
+test( "Math.pow ( -0, -0 ) ", Math.pow ( -0, -0 ) , 1 );
 
 
-test( "Math.pow ( -0, 1 ) ", Math.pow ( -0, 1 ) , 0 ); 
+test( "Math.pow ( -0, 1 ) ", Math.pow ( -0, 1 ) , 0 );
 
 
-test( "Math.pow ( -0, 1.012 ) ", Math.pow ( -0, 1.012 ) , 0 ); 
+test( "Math.pow ( -0, 1.012 ) ", Math.pow ( -0, 1.012 ) , 0 );
 
 
-test( "Math.pow ( -0, -1.12 ) ", Math.pow ( -0, -1.12 ) , Infinity ); 
+test( "Math.pow ( -0, -1.12 ) ", Math.pow ( -0, -1.12 ) , Infinity );
 
 
-test( "Math.pow ( -0, 0.499 ) ", Math.pow ( -0, 0.499 ) , 0 ); 
+test( "Math.pow ( -0, 0.499 ) ", Math.pow ( -0, 0.499 ) , 0 );
 
 
-test( "Math.pow ( -0, -0.5 ) ", Math.pow ( -0, -0.5 ) , Infinity ); 
+test( "Math.pow ( -0, -0.5 ) ", Math.pow ( -0, -0.5 ) , Infinity );
 
 
-test( "Math.pow ( 1, Number.POSITIVE_INFINITY ) ", Math.pow ( 1, Number.POSITIVE_INFINITY ) , Number.NaN ); 
+test( "Math.pow ( 1, Number.POSITIVE_INFINITY ) ", Math.pow ( 1, Number.POSITIVE_INFINITY ) , Number.NaN );
 
 
-test( "Math.pow ( 1, Number.NEGATIVE_INFINITY ) ", Math.pow ( 1, Number.NEGATIVE_INFINITY ) , Number.NaN ); 
+test( "Math.pow ( 1, Number.NEGATIVE_INFINITY ) ", Math.pow ( 1, Number.NEGATIVE_INFINITY ) , Number.NaN );
 
 
-test( "Math.pow ( 1, Number.MAX_VALUE ) ", Math.pow ( 1, Number.MAX_VALUE ) , 1 ); 
+test( "Math.pow ( 1, Number.MAX_VALUE ) ", Math.pow ( 1, Number.MAX_VALUE ) , 1 );
 
 
-test( "Math.pow ( 1, Number.MIN_VALUE ) ", Math.pow ( 1, Number.MIN_VALUE ) , 1 ); 
+test( "Math.pow ( 1, Number.MIN_VALUE ) ", Math.pow ( 1, Number.MIN_VALUE ) , 1 );
 
 
-test( "Math.pow ( 1, Number.NaN ) ", Math.pow ( 1, Number.NaN ) , Number.NaN ); 
+test( "Math.pow ( 1, Number.NaN ) ", Math.pow ( 1, Number.NaN ) , Number.NaN );
 
 
-test( "Math.pow ( 1, 0 ) ", Math.pow ( 1, 0 ) , 1 ); 
+test( "Math.pow ( 1, 0 ) ", Math.pow ( 1, 0 ) , 1 );
 
 
-test( "Math.pow ( 1, -0 ) ", Math.pow ( 1, -0 ) , 1 ); 
+test( "Math.pow ( 1, -0 ) ", Math.pow ( 1, -0 ) , 1 );
 
 
-test( "Math.pow ( 1, 1 ) ", Math.pow ( 1, 1 ) , 1 ); 
+test( "Math.pow ( 1, 1 ) ", Math.pow ( 1, 1 ) , 1 );
 
 
-test( "Math.pow ( 1, 1.012 ) ", Math.pow ( 1, 1.012 ) , 1 ); 
+test( "Math.pow ( 1, 1.012 ) ", Math.pow ( 1, 1.012 ) , 1 );
 
 
-test( "Math.pow ( 1, -1.12 ) ", Math.pow ( 1, -1.12 ) , 1 ); 
+test( "Math.pow ( 1, -1.12 ) ", Math.pow ( 1, -1.12 ) , 1 );
 
 
-test( "Math.pow ( 1, 0.499 ) ", Math.pow ( 1, 0.499 ) , 1 ); 
+test( "Math.pow ( 1, 0.499 ) ", Math.pow ( 1, 0.499 ) , 1 );
 
 
-test( "Math.pow ( 1, -0.5 ) ", Math.pow ( 1, -0.5 ) , 1 ); 
+test( "Math.pow ( 1, -0.5 ) ", Math.pow ( 1, -0.5 ) , 1 );
 
 
-test( "Math.pow ( 1.012, Number.POSITIVE_INFINITY ) ", Math.pow ( 1.012, Number.POSITIVE_INFINITY ) , Infinity ); 
+test( "Math.pow ( 1.012, Number.POSITIVE_INFINITY ) ", Math.pow ( 1.012, Number.POSITIVE_INFINITY ) , Infinity );
 
 
-test( "Math.pow ( 1.012, Number.NEGATIVE_INFINITY ) ", Math.pow ( 1.012, Number.NEGATIVE_INFINITY ) , 0 ); 
+test( "Math.pow ( 1.012, Number.NEGATIVE_INFINITY ) ", Math.pow ( 1.012, Number.NEGATIVE_INFINITY ) , 0 );
 
 
-test( "Math.pow ( 1.012, Number.MAX_VALUE ) ", Math.pow ( 1.012, Number.MAX_VALUE ) , Infinity ); 
+test( "Math.pow ( 1.012, Number.MAX_VALUE ) ", Math.pow ( 1.012, Number.MAX_VALUE ) , Infinity );
 
 
-test( "Math.pow ( 1.012, Number.MIN_VALUE ) ", Math.pow ( 1.012, Number.MIN_VALUE ) , 1 ); 
+test( "Math.pow ( 1.012, Number.MIN_VALUE ) ", Math.pow ( 1.012, Number.MIN_VALUE ) , 1 );
 
 
-test( "Math.pow ( 1.012, Number.NaN ) ", Math.pow ( 1.012, Number.NaN ) , Number.NaN ); 
+test( "Math.pow ( 1.012, Number.NaN ) ", Math.pow ( 1.012, Number.NaN ) , Number.NaN );
 
 
-test( "Math.pow ( 1.012, 0 ) ", Math.pow ( 1.012, 0 ) , 1 ); 
+test( "Math.pow ( 1.012, 0 ) ", Math.pow ( 1.012, 0 ) , 1 );
 
 
-test( "Math.pow ( 1.012, -0 ) ", Math.pow ( 1.012, -0 ) , 1 ); 
+test( "Math.pow ( 1.012, -0 ) ", Math.pow ( 1.012, -0 ) , 1 );
 
 
-test( "Math.pow ( 1.012, 1 ) ", Math.pow ( 1.012, 1 ) , 1.012 ); 
+test( "Math.pow ( 1.012, 1 ) ", Math.pow ( 1.012, 1 ) , 1.012 );
 
 
-teste( "Math.pow ( 1.012, 1.012 ) ", Math.pow ( 1.012, 1.012 ) , 1.0121448709329596 ); 
+teste( "Math.pow ( 1.012, 1.012 ) ", Math.pow ( 1.012, 1.012 ) , 1.0121448709329596 );
 
 
-teste( "Math.pow ( 1.012, -1.12 ) ", Math.pow ( 1.012, -1.12 ) , 0.986728849309578 ); 
+teste( "Math.pow ( 1.012, -1.12 ) ", Math.pow ( 1.012, -1.12 ) , 0.986728849309578 );
 
 
-teste( "Math.pow ( 1.012, 0.499 ) ", Math.pow ( 1.012, 0.499 ) , 1.0059701073394591 ); 
+teste( "Math.pow ( 1.012, 0.499 ) ", Math.pow ( 1.012, 0.499 ) , 1.0059701073394591 );
 
 
-teste( "Math.pow ( 1.012, -0.5 ) ", Math.pow ( 1.012, -0.5 ) , 0.9940534656094302 ); 
+teste( "Math.pow ( 1.012, -0.5 ) ", Math.pow ( 1.012, -0.5 ) , 0.9940534656094302 );
 
 
-test( "Math.pow ( -1.12, Number.POSITIVE_INFINITY ) ", Math.pow ( -1.12, Number.POSITIVE_INFINITY ) , Infinity ); 
+test( "Math.pow ( -1.12, Number.POSITIVE_INFINITY ) ", Math.pow ( -1.12, Number.POSITIVE_INFINITY ) , Infinity );
 
 
-test( "Math.pow ( -1.12, Number.NEGATIVE_INFINITY ) ", Math.pow ( -1.12, Number.NEGATIVE_INFINITY ) , 0 ); 
+test( "Math.pow ( -1.12, Number.NEGATIVE_INFINITY ) ", Math.pow ( -1.12, Number.NEGATIVE_INFINITY ) , 0 );
 
 
-test( "Math.pow ( -1.12, Number.MAX_VALUE ) ", Math.pow ( -1.12, Number.MAX_VALUE ) , Infinity ); 
+test( "Math.pow ( -1.12, Number.MAX_VALUE ) ", Math.pow ( -1.12, Number.MAX_VALUE ) , Infinity );
 
 
-test( "Math.pow ( -1.12, Number.MIN_VALUE ) ", Math.pow ( -1.12, Number.MIN_VALUE ) , Number.NaN ); 
+test( "Math.pow ( -1.12, Number.MIN_VALUE ) ", Math.pow ( -1.12, Number.MIN_VALUE ) , Number.NaN );
 
 
-test( "Math.pow ( -1.12, Number.NaN ) ", Math.pow ( -1.12, Number.NaN ) , Number.NaN ); 
+test( "Math.pow ( -1.12, Number.NaN ) ", Math.pow ( -1.12, Number.NaN ) , Number.NaN );
 
 
-test( "Math.pow ( -1.12, 0 ) ", Math.pow ( -1.12, 0 ) , 1 ); 
+test( "Math.pow ( -1.12, 0 ) ", Math.pow ( -1.12, 0 ) , 1 );
 
 
-test( "Math.pow ( -1.12, -0 ) ", Math.pow ( -1.12, -0 ) , 1 ); 
+test( "Math.pow ( -1.12, -0 ) ", Math.pow ( -1.12, -0 ) , 1 );
 
 
-test( "Math.pow ( -1.12, 1 ) ", Math.pow ( -1.12, 1 ) , -1.12 ); 
+test( "Math.pow ( -1.12, 1 ) ", Math.pow ( -1.12, 1 ) , -1.12 );
 
 
-test( "Math.pow ( -1.12, 1.012 ) ", Math.pow ( -1.12, 1.012 ) , Number.NaN ); 
+test( "Math.pow ( -1.12, 1.012 ) ", Math.pow ( -1.12, 1.012 ) , Number.NaN );
 
 
-test( "Math.pow ( -1.12, -1.12 ) ", Math.pow ( -1.12, -1.12 ) , Number.NaN ); 
+test( "Math.pow ( -1.12, -1.12 ) ", Math.pow ( -1.12, -1.12 ) , Number.NaN );
 
 
-test( "Math.pow ( -1.12, 0.499 ) ", Math.pow ( -1.12, 0.499 ) , Number.NaN ); 
+test( "Math.pow ( -1.12, 0.499 ) ", Math.pow ( -1.12, 0.499 ) , Number.NaN );
 
 
-test( "Math.pow ( -1.12, -0.5 ) ", Math.pow ( -1.12, -0.5 ) , Number.NaN ); 
+test( "Math.pow ( -1.12, -0.5 ) ", Math.pow ( -1.12, -0.5 ) , Number.NaN );
 
 
-test( "Math.pow ( 0.499, Number.POSITIVE_INFINITY ) ", Math.pow ( 0.499, Number.POSITIVE_INFINITY ) , 0 ); 
+test( "Math.pow ( 0.499, Number.POSITIVE_INFINITY ) ", Math.pow ( 0.499, Number.POSITIVE_INFINITY ) , 0 );
 
 
-test( "Math.pow ( 0.499, Number.NEGATIVE_INFINITY ) ", Math.pow ( 0.499, Number.NEGATIVE_INFINITY ) , Infinity ); 
+test( "Math.pow ( 0.499, Number.NEGATIVE_INFINITY ) ", Math.pow ( 0.499, Number.NEGATIVE_INFINITY ) , Infinity );
 
 
-test( "Math.pow ( 0.499, Number.MAX_VALUE ) ", Math.pow ( 0.499, Number.MAX_VALUE ) , 0 ); 
+test( "Math.pow ( 0.499, Number.MAX_VALUE ) ", Math.pow ( 0.499, Number.MAX_VALUE ) , 0 );
 
 
-test( "Math.pow ( 0.499, Number.MIN_VALUE ) ", Math.pow ( 0.499, Number.MIN_VALUE ) , 1 ); 
+test( "Math.pow ( 0.499, Number.MIN_VALUE ) ", Math.pow ( 0.499, Number.MIN_VALUE ) , 1 );
 
 
-test( "Math.pow ( 0.499, Number.NaN ) ", Math.pow ( 0.499, Number.NaN ) , Number.NaN ); 
+test( "Math.pow ( 0.499, Number.NaN ) ", Math.pow ( 0.499, Number.NaN ) , Number.NaN );
 
 
-test( "Math.pow ( 0.499, 0 ) ", Math.pow ( 0.499, 0 ) , 1 ); 
+test( "Math.pow ( 0.499, 0 ) ", Math.pow ( 0.499, 0 ) , 1 );
 
 
-test( "Math.pow ( 0.499, -0 ) ", Math.pow ( 0.499, -0 ) , 1 ); 
+test( "Math.pow ( 0.499, -0 ) ", Math.pow ( 0.499, -0 ) , 1 );
 
 
-test( "Math.pow ( 0.499, 1 ) ", Math.pow ( 0.499, 1 ) , 0.499 ); 
+test( "Math.pow ( 0.499, 1 ) ", Math.pow ( 0.499, 1 ) , 0.499 );
 
 
-teste( "Math.pow ( 0.499, 1.012 ) ", Math.pow ( 0.499, 1.012 ) , 0.49485476008898793 ); 
+teste( "Math.pow ( 0.499, 1.012 ) ", Math.pow ( 0.499, 1.012 ) , 0.49485476008898793 );
 
 
-teste( "Math.pow ( 0.499, -1.12 ) ", Math.pow ( 0.499, -1.12 ) , 2.178348640122035 ); 
+teste( "Math.pow ( 0.499, -1.12 ) ", Math.pow ( 0.499, -1.12 ) , 2.178348640122035 );
 
 
-teste( "Math.pow ( 0.499, 0.499 ) ", Math.pow ( 0.499, 0.499 ) , 0.7068905441257238 ); 
+teste( "Math.pow ( 0.499, 0.499 ) ", Math.pow ( 0.499, 0.499 ) , 0.7068905441257238 );
 
 
-teste( "Math.pow ( 0.499, -0.5 ) ", Math.pow ( 0.499, -0.5 ) , 1.415629900797544 ); 
+teste( "Math.pow ( 0.499, -0.5 ) ", Math.pow ( 0.499, -0.5 ) , 1.415629900797544 );
 
 
-test( "Math.pow ( -0.5, Number.POSITIVE_INFINITY ) ", Math.pow ( -0.5, Number.POSITIVE_INFINITY ) , 0 ); 
+test( "Math.pow ( -0.5, Number.POSITIVE_INFINITY ) ", Math.pow ( -0.5, Number.POSITIVE_INFINITY ) , 0 );
 
 
-test( "Math.pow ( -0.5, Number.NEGATIVE_INFINITY ) ", Math.pow ( -0.5, Number.NEGATIVE_INFINITY ) , Infinity ); 
+test( "Math.pow ( -0.5, Number.NEGATIVE_INFINITY ) ", Math.pow ( -0.5, Number.NEGATIVE_INFINITY ) , Infinity );
 
 
-test( "Math.pow ( -0.5, Number.MAX_VALUE ) ", Math.pow ( -0.5, Number.MAX_VALUE ) , 0 ); 
+test( "Math.pow ( -0.5, Number.MAX_VALUE ) ", Math.pow ( -0.5, Number.MAX_VALUE ) , 0 );
 
 
-test( "Math.pow ( -0.5, Number.MIN_VALUE ) ", Math.pow ( -0.5, Number.MIN_VALUE ) , Number.NaN ); 
+test( "Math.pow ( -0.5, Number.MIN_VALUE ) ", Math.pow ( -0.5, Number.MIN_VALUE ) , Number.NaN );
 
 
-test( "Math.pow ( -0.5, Number.NaN ) ", Math.pow ( -0.5, Number.NaN ) , Number.NaN ); 
+test( "Math.pow ( -0.5, Number.NaN ) ", Math.pow ( -0.5, Number.NaN ) , Number.NaN );
 
 
-test( "Math.pow ( -0.5, 0 ) ", Math.pow ( -0.5, 0 ) , 1 ); 
+test( "Math.pow ( -0.5, 0 ) ", Math.pow ( -0.5, 0 ) , 1 );
 
 
-test( "Math.pow ( -0.5, -0 ) ", Math.pow ( -0.5, -0 ) , 1 ); 
+test( "Math.pow ( -0.5, -0 ) ", Math.pow ( -0.5, -0 ) , 1 );
 
 
-test( "Math.pow ( -0.5, 1 ) ", Math.pow ( -0.5, 1 ) , -0.5 ); 
+test( "Math.pow ( -0.5, 1 ) ", Math.pow ( -0.5, 1 ) , -0.5 );
 
 
-test( "Math.pow ( -0.5, 1.012 ) ", Math.pow ( -0.5, 1.012 ) , Number.NaN ); 
+test( "Math.pow ( -0.5, 1.012 ) ", Math.pow ( -0.5, 1.012 ) , Number.NaN );
 
 
-test( "Math.pow ( -0.5, -1.12 ) ", Math.pow ( -0.5, -1.12 ) , Number.NaN ); 
+test( "Math.pow ( -0.5, -1.12 ) ", Math.pow ( -0.5, -1.12 ) , Number.NaN );
 
 
-test( "Math.pow ( -0.5, 0.499 ) ", Math.pow ( -0.5, 0.499 ) , Number.NaN ); 
+test( "Math.pow ( -0.5, 0.499 ) ", Math.pow ( -0.5, 0.499 ) , Number.NaN );
 
 
-test( "Math.pow ( -0.5, -0.5 ) ", Math.pow ( -0.5, -0.5 ) , Number.NaN ); 
+test( "Math.pow ( -0.5, -0.5 ) ", Math.pow ( -0.5, -0.5 ) , Number.NaN );
 
 
 

--- a/core/standards/scripts/jstest-core-2/es-regression/scripts/mathpropsops.js
+++ b/core/standards/scripts/jstest-core-2/es-regression/scripts/mathpropsops.js
@@ -4,7 +4,7 @@
  *
  * Comments: this test uses these properties of the Math and Number constructors:
  *
- *   Math.E, Math.LN2, Math.LN10, Math.LOG2E, Math.LOG10E, Math.PI, Math.SQRT1_2, Math.SQRT2, 
+ *   Math.E, Math.LN2, Math.LN10, Math.LOG2E, Math.LOG10E, Math.PI, Math.SQRT1_2, Math.SQRT2,
  *   Number.POSITIVE_INFINITY, Number.NEGATIVE_INFINITY, Number.MAX_VALUE, Number.MIN_VALUE, Number.NaN
  *
  * with these operators:
@@ -40,91 +40,91 @@ try {
 
 testcase( "Maths properties and assignment operators..." );
 
-n=0; 
-test( "n=0;<BR>n = 0+Math.E", n = 0+Math.E, 2.718281828459045 ); 
+n=0;
+test( "n=0;<BR>n = 0+Math.E", n = 0+Math.E, 2.718281828459045 );
 
 
-n=12345; 
-test( "n=12345;<BR>n = 12345+Math.E", n = 12345+Math.E, 12347.718281828458 ); 
-
-
-n=-12345;
-test( "n=-12345;<BR>n = -12345+Math.E", n = -12345+Math.E, -12342.281718171541 ); 
-
-
-n=0x45ae;
-test( "n=0x45ae;<BR>n = 17838+Math.E", n = 17838+Math.E, 17840.71828182846 ); 
-
-
-n=0; 
-test( "n=0;<BR>n = 0-Math.E", n = 0-Math.E, -2.718281828459045 ); 
-
-
-n=12345; 
-test( "n=12345;<BR>n = 12345-Math.E", n = 12345-Math.E, 12342.281718171541 ); 
+n=12345;
+test( "n=12345;<BR>n = 12345+Math.E", n = 12345+Math.E, 12347.718281828458 );
 
 
 n=-12345;
-test( "n=-12345;<BR>n = -12345-Math.E", n = -12345-Math.E, -12347.718281828458 ); 
+test( "n=-12345;<BR>n = -12345+Math.E", n = -12345+Math.E, -12342.281718171541 );
 
 
 n=0x45ae;
-test( "n=0x45ae;<BR>n = 17838-Math.E", n = 17838-Math.E, 17835.28171817154 ); 
-
-
-n=0; 
-test( "n=0;<BR>n = 0*Math.E", n = 0*Math.E, 0 ); 
-
-
-n=12345; 
-test( "n=12345;<BR>n = 12345*Math.E", n = 12345*Math.E, 33557.189172326914 ); 
-
-
-n=-12345;
-test( "n=-12345;<BR>n = -12345*Math.E", n = -12345*Math.E, -33557.189172326914 ); 
-
-
-n=0x45ae;
-test( "n=0x45ae;<BR>n = 17838*Math.E", n = 17838*Math.E, 48488.71125605245 ); 
-
-
-n=0; 
-test( "n=0;<BR>n = 0/Math.E", n = 0/Math.E, 0 ); 
-
-
-n=12345; 
-test( "n=12345;<BR>n = 12345/Math.E", n = 12345/Math.E, 4541.471701261456 ); 
-
-
-n=-12345;
-test( "n=-12345;<BR>n = -12345/Math.E", n = -12345/Math.E, -4541.471701261456 ); 
-
-
-n=0x45ae;
-test( "n=0x45ae;<BR>n = 17838/Math.E", n = 17838/Math.E, 6562.233471616189 ); 
-
-
-n=0; 
-test( "n=0;<BR>n = 0%Math.E", n = 0%Math.E, 0 ); 
-
-
-n=12345; 
-test( "n=12345;<BR>n = 12345%Math.E", n = 12345%Math.E, 1.2822169674762427 ); 
-
-
-n=-12345;
-test( "n=-12345;<BR>n = -12345%Math.E", n = -12345%Math.E, -1.2822169674762427 ); 
-
-
-n=0x45ae;
-test( "n=0x45ae;<BR>n = 17838%Math.E", n = 17838%Math.E, 0.6346416517461142 ); 
+test( "n=0x45ae;<BR>n = 17838+Math.E", n = 17838+Math.E, 17840.71828182846 );
 
 
 n=0;
-test( "n=0;<BR>n +=Math.E", n +=Math.E, 2.718281828459045 ); 
+test( "n=0;<BR>n = 0-Math.E", n = 0-Math.E, -2.718281828459045 );
 
 
-n=12345; 
+n=12345;
+test( "n=12345;<BR>n = 12345-Math.E", n = 12345-Math.E, 12342.281718171541 );
+
+
+n=-12345;
+test( "n=-12345;<BR>n = -12345-Math.E", n = -12345-Math.E, -12347.718281828458 );
+
+
+n=0x45ae;
+test( "n=0x45ae;<BR>n = 17838-Math.E", n = 17838-Math.E, 17835.28171817154 );
+
+
+n=0;
+test( "n=0;<BR>n = 0*Math.E", n = 0*Math.E, 0 );
+
+
+n=12345;
+test( "n=12345;<BR>n = 12345*Math.E", n = 12345*Math.E, 33557.189172326914 );
+
+
+n=-12345;
+test( "n=-12345;<BR>n = -12345*Math.E", n = -12345*Math.E, -33557.189172326914 );
+
+
+n=0x45ae;
+test( "n=0x45ae;<BR>n = 17838*Math.E", n = 17838*Math.E, 48488.71125605245 );
+
+
+n=0;
+test( "n=0;<BR>n = 0/Math.E", n = 0/Math.E, 0 );
+
+
+n=12345;
+test( "n=12345;<BR>n = 12345/Math.E", n = 12345/Math.E, 4541.471701261456 );
+
+
+n=-12345;
+test( "n=-12345;<BR>n = -12345/Math.E", n = -12345/Math.E, -4541.471701261456 );
+
+
+n=0x45ae;
+test( "n=0x45ae;<BR>n = 17838/Math.E", n = 17838/Math.E, 6562.233471616189 );
+
+
+n=0;
+test( "n=0;<BR>n = 0%Math.E", n = 0%Math.E, 0 );
+
+
+n=12345;
+test( "n=12345;<BR>n = 12345%Math.E", n = 12345%Math.E, 1.2822169674762427 );
+
+
+n=-12345;
+test( "n=-12345;<BR>n = -12345%Math.E", n = -12345%Math.E, -1.2822169674762427 );
+
+
+n=0x45ae;
+test( "n=0x45ae;<BR>n = 17838%Math.E", n = 17838%Math.E, 0.6346416517461142 );
+
+
+n=0;
+test( "n=0;<BR>n +=Math.E", n +=Math.E, 2.718281828459045 );
+
+
+n=12345;
 test( "n=12345;<BR>n +=Math.E", n +=Math.E, 12347.718281828458 );
 
 
@@ -137,10 +137,10 @@ test( "n=0x45ae;<BR>n +=Math.E", n +=Math.E, 17840.71828182846 );
 
 
 n=0;
-test( "n=0;<BR>n -=Math.E", n -=Math.E, -2.718281828459045 ); 
+test( "n=0;<BR>n -=Math.E", n -=Math.E, -2.718281828459045 );
 
 
-n=12345; 
+n=12345;
 test( "n=12345;<BR>n -=Math.E", n -=Math.E, 12342.281718171541 );
 
 
@@ -153,10 +153,10 @@ test( "n=0x45ae;<BR>n -=Math.E", n -=Math.E, 17835.28171817154 );
 
 
 n=0;
-test( "n=0;<BR>n *=Math.E", n *=Math.E, 0 ); 
+test( "n=0;<BR>n *=Math.E", n *=Math.E, 0 );
 
 
-n=12345; 
+n=12345;
 test( "n=12345;<BR>n *=Math.E", n *=Math.E, 33557.189172326914 );
 
 
@@ -169,10 +169,10 @@ test( "n=0x45ae;<BR>n *=Math.E", n *=Math.E, 48488.71125605245 );
 
 
 n=0;
-test( "n=0;<BR>n /=Math.E", n /=Math.E, 0 ); 
+test( "n=0;<BR>n /=Math.E", n /=Math.E, 0 );
 
 
-n=12345; 
+n=12345;
 test( "n=12345;<BR>n /=Math.E", n /=Math.E, 4541.471701261456 );
 
 
@@ -185,10 +185,10 @@ test( "n=0x45ae;<BR>n /=Math.E", n /=Math.E, 6562.233471616189 );
 
 
 n=0;
-test( "n=0;<BR>n %=Math.E", n %=Math.E, 0 ); 
+test( "n=0;<BR>n %=Math.E", n %=Math.E, 0 );
 
 
-n=12345; 
+n=12345;
 test( "n=12345;<BR>n %=Math.E", n %=Math.E, 1.2822169674762427 );
 
 
@@ -200,91 +200,91 @@ n=0x45ae;
 test( "n=0x45ae;<BR>n %=Math.E", n %=Math.E, 0.6346416517461142 );
 
 
-n=0; 
-test( "n=0;<BR>n = 0+Math.LN2", n = 0+Math.LN2, 0.6931471805599453 ); 
+n=0;
+test( "n=0;<BR>n = 0+Math.LN2", n = 0+Math.LN2, 0.6931471805599453 );
 
 
-n=12345; 
-test( "n=12345;<BR>n = 12345+Math.LN2", n = 12345+Math.LN2, 12345.69314718056 ); 
-
-
-n=-12345;
-test( "n=-12345;<BR>n = -12345+Math.LN2", n = -12345+Math.LN2, -12344.30685281944 ); 
-
-
-n=0x45ae;
-test( "n=0x45ae;<BR>n = 17838+Math.LN2", n = 17838+Math.LN2, 17838.69314718056 ); 
-
-
-n=0; 
-test( "n=0;<BR>n = 0-Math.LN2", n = 0-Math.LN2, -0.6931471805599453 ); 
-
-
-n=12345; 
-test( "n=12345;<BR>n = 12345-Math.LN2", n = 12345-Math.LN2, 12344.30685281944 ); 
+n=12345;
+test( "n=12345;<BR>n = 12345+Math.LN2", n = 12345+Math.LN2, 12345.69314718056 );
 
 
 n=-12345;
-test( "n=-12345;<BR>n = -12345-Math.LN2", n = -12345-Math.LN2, -12345.69314718056 ); 
+test( "n=-12345;<BR>n = -12345+Math.LN2", n = -12345+Math.LN2, -12344.30685281944 );
 
 
 n=0x45ae;
-test( "n=0x45ae;<BR>n = 17838-Math.LN2", n = 17838-Math.LN2, 17837.30685281944 ); 
-
-
-n=0; 
-test( "n=0;<BR>n = 0*Math.LN2", n = 0*Math.LN2, 0 ); 
-
-
-n=12345; 
-test( "n=12345;<BR>n = 12345*Math.LN2", n = 12345*Math.LN2, 8556.901944012524 ); 
-
-
-n=-12345;
-test( "n=-12345;<BR>n = -12345*Math.LN2", n = -12345*Math.LN2, -8556.901944012524 ); 
-
-
-n=0x45ae;
-test( "n=0x45ae;<BR>n = 17838*Math.LN2", n = 17838*Math.LN2, 12364.359406828303 ); 
-
-
-n=0; 
-test( "n=0;<BR>n = 0/Math.LN2", n = 0/Math.LN2, 0 ); 
-
-
-n=12345; 
-test( "n=12345;<BR>n = 12345/Math.LN2", n = 12345/Math.LN2, 17810.070279774252 ); 
-
-
-n=-12345;
-test( "n=-12345;<BR>n = -12345/Math.LN2", n = -12345/Math.LN2, -17810.070279774252 ); 
-
-
-n=0x45ae;
-test( "n=0x45ae;<BR>n = 17838/Math.LN2", n = 17838/Math.LN2, 25734.79413937733 ); 
-
-
-n=0; 
-test( "n=0;<BR>n = 0%Math.LN2", n = 0%Math.LN2, 0 ); 
-
-
-n=12345; 
-test( "n=12345;<BR>n = 12345%Math.LN2", n = 12345%Math.LN2, 0.0487142273744523 ); 
-
-
-n=-12345;
-test( "n=-12345;<BR>n = -12345%Math.LN2", n = -12345%Math.LN2, -0.0487142273744523 ); 
-
-
-n=0x45ae;
-test( "n=0x45ae;<BR>n = 17838%Math.LN2", n = 17838%Math.LN2, 0.5504554703680042 ); 
+test( "n=0x45ae;<BR>n = 17838+Math.LN2", n = 17838+Math.LN2, 17838.69314718056 );
 
 
 n=0;
-test( "n=0;<BR>n +=Math.LN2", n +=Math.LN2, 0.6931471805599453 ); 
+test( "n=0;<BR>n = 0-Math.LN2", n = 0-Math.LN2, -0.6931471805599453 );
 
 
-n=12345; 
+n=12345;
+test( "n=12345;<BR>n = 12345-Math.LN2", n = 12345-Math.LN2, 12344.30685281944 );
+
+
+n=-12345;
+test( "n=-12345;<BR>n = -12345-Math.LN2", n = -12345-Math.LN2, -12345.69314718056 );
+
+
+n=0x45ae;
+test( "n=0x45ae;<BR>n = 17838-Math.LN2", n = 17838-Math.LN2, 17837.30685281944 );
+
+
+n=0;
+test( "n=0;<BR>n = 0*Math.LN2", n = 0*Math.LN2, 0 );
+
+
+n=12345;
+test( "n=12345;<BR>n = 12345*Math.LN2", n = 12345*Math.LN2, 8556.901944012524 );
+
+
+n=-12345;
+test( "n=-12345;<BR>n = -12345*Math.LN2", n = -12345*Math.LN2, -8556.901944012524 );
+
+
+n=0x45ae;
+test( "n=0x45ae;<BR>n = 17838*Math.LN2", n = 17838*Math.LN2, 12364.359406828303 );
+
+
+n=0;
+test( "n=0;<BR>n = 0/Math.LN2", n = 0/Math.LN2, 0 );
+
+
+n=12345;
+test( "n=12345;<BR>n = 12345/Math.LN2", n = 12345/Math.LN2, 17810.070279774252 );
+
+
+n=-12345;
+test( "n=-12345;<BR>n = -12345/Math.LN2", n = -12345/Math.LN2, -17810.070279774252 );
+
+
+n=0x45ae;
+test( "n=0x45ae;<BR>n = 17838/Math.LN2", n = 17838/Math.LN2, 25734.79413937733 );
+
+
+n=0;
+test( "n=0;<BR>n = 0%Math.LN2", n = 0%Math.LN2, 0 );
+
+
+n=12345;
+test( "n=12345;<BR>n = 12345%Math.LN2", n = 12345%Math.LN2, 0.0487142273744523 );
+
+
+n=-12345;
+test( "n=-12345;<BR>n = -12345%Math.LN2", n = -12345%Math.LN2, -0.0487142273744523 );
+
+
+n=0x45ae;
+test( "n=0x45ae;<BR>n = 17838%Math.LN2", n = 17838%Math.LN2, 0.5504554703680042 );
+
+
+n=0;
+test( "n=0;<BR>n +=Math.LN2", n +=Math.LN2, 0.6931471805599453 );
+
+
+n=12345;
 test( "n=12345;<BR>n +=Math.LN2", n +=Math.LN2, 12345.69314718056 );
 
 
@@ -297,10 +297,10 @@ test( "n=0x45ae;<BR>n +=Math.LN2", n +=Math.LN2, 17838.69314718056 );
 
 
 n=0;
-test( "n=0;<BR>n -=Math.LN2", n -=Math.LN2, -0.6931471805599453 ); 
+test( "n=0;<BR>n -=Math.LN2", n -=Math.LN2, -0.6931471805599453 );
 
 
-n=12345; 
+n=12345;
 test( "n=12345;<BR>n -=Math.LN2", n -=Math.LN2, 12344.30685281944 );
 
 
@@ -313,10 +313,10 @@ test( "n=0x45ae;<BR>n -=Math.LN2", n -=Math.LN2, 17837.30685281944 );
 
 
 n=0;
-test( "n=0;<BR>n *=Math.LN2", n *=Math.LN2, 0 ); 
+test( "n=0;<BR>n *=Math.LN2", n *=Math.LN2, 0 );
 
 
-n=12345; 
+n=12345;
 test( "n=12345;<BR>n *=Math.LN2", n *=Math.LN2, 8556.901944012524 );
 
 
@@ -329,10 +329,10 @@ test( "n=0x45ae;<BR>n *=Math.LN2", n *=Math.LN2, 12364.359406828303 );
 
 
 n=0;
-test( "n=0;<BR>n /=Math.LN2", n /=Math.LN2, 0 ); 
+test( "n=0;<BR>n /=Math.LN2", n /=Math.LN2, 0 );
 
 
-n=12345; 
+n=12345;
 test( "n=12345;<BR>n /=Math.LN2", n /=Math.LN2, 17810.070279774252 );
 
 
@@ -345,10 +345,10 @@ test( "n=0x45ae;<BR>n /=Math.LN2", n /=Math.LN2, 25734.79413937733 );
 
 
 n=0;
-test( "n=0;<BR>n %=Math.LN2", n %=Math.LN2, 0 ); 
+test( "n=0;<BR>n %=Math.LN2", n %=Math.LN2, 0 );
 
 
-n=12345; 
+n=12345;
 test( "n=12345;<BR>n %=Math.LN2", n %=Math.LN2, 0.0487142273744523 );
 
 
@@ -360,91 +360,91 @@ n=0x45ae;
 test( "n=0x45ae;<BR>n %=Math.LN2", n %=Math.LN2, 0.5504554703680042 );
 
 
-n=0; 
-test( "n=0;<BR>n = 0+Math.LN10", n = 0+Math.LN10, 2.302585092994046 ); 
+n=0;
+test( "n=0;<BR>n = 0+Math.LN10", n = 0+Math.LN10, 2.302585092994046 );
 
 
-n=12345; 
-test( "n=12345;<BR>n = 12345+Math.LN10", n = 12345+Math.LN10, 12347.302585092993 ); 
-
-
-n=-12345;
-test( "n=-12345;<BR>n = -12345+Math.LN10", n = -12345+Math.LN10, -12342.697414907006 ); 
-
-
-n=0x45ae;
-test( "n=0x45ae;<BR>n = 17838+Math.LN10", n = 17838+Math.LN10, 17840.302585092995 ); 
-
-
-n=0; 
-test( "n=0;<BR>n = 0-Math.LN10", n = 0-Math.LN10, -2.302585092994046 ); 
-
-
-n=12345; 
-test( "n=12345;<BR>n = 12345-Math.LN10", n = 12345-Math.LN10, 12342.697414907006 ); 
+n=12345;
+test( "n=12345;<BR>n = 12345+Math.LN10", n = 12345+Math.LN10, 12347.302585092993 );
 
 
 n=-12345;
-test( "n=-12345;<BR>n = -12345-Math.LN10", n = -12345-Math.LN10, -12347.302585092993 ); 
+test( "n=-12345;<BR>n = -12345+Math.LN10", n = -12345+Math.LN10, -12342.697414907006 );
 
 
 n=0x45ae;
-test( "n=0x45ae;<BR>n = 17838-Math.LN10", n = 17838-Math.LN10, 17835.697414907004 ); 
-
-
-n=0; 
-test( "n=0;<BR>n = 0*Math.LN10", n = 0*Math.LN10, 0 ); 
-
-
-n=12345; 
-test( "n=12345;<BR>n = 12345*Math.LN10", n = 12345*Math.LN10, 28425.4129730115 ); 
-
-
-n=-12345;
-test( "n=-12345;<BR>n = -12345*Math.LN10", n = -12345*Math.LN10, -28425.4129730115 ); 
-
-
-n=0x45ae;
-test( "n=0x45ae;<BR>n = 17838*Math.LN10", n = 17838*Math.LN10, 41073.51288882779 ); 
-
-
-n=0; 
-test( "n=0;<BR>n = 0/Math.LN10", n = 0/Math.LN10, 0 ); 
-
-
-n=12345; 
-test( "n=12345;<BR>n = 12345/Math.LN10", n = 12345/Math.LN10, 5361.365379095643 ); 
-
-
-n=-12345;
-test( "n=-12345;<BR>n = -12345/Math.LN10", n = -12345/Math.LN10, -5361.365379095643 ); 
-
-
-n=0x45ae;
-test( "n=0x45ae;<BR>n = 17838/Math.LN10", n = 17838/Math.LN10, 7746.944968190205 ); 
-
-
-n=0; 
-test( "n=0;<BR>n = 0%Math.LN10", n = 0%Math.LN10, 0 ); 
-
-
-n=12345; 
-test( "n=12345;<BR>n = 12345%Math.LN10", n = 12345%Math.LN10, 0.8413164589199242 ); 
-
-
-n=-12345;
-test( "n=-12345;<BR>n = -12345%Math.LN10", n = -12345%Math.LN10, -0.8413164589199242 ); 
-
-
-n=0x45ae;
-test( "n=0x45ae;<BR>n = 17838%Math.LN10", n = 17838%Math.LN10, 2.17586966812045 ); 
+test( "n=0x45ae;<BR>n = 17838+Math.LN10", n = 17838+Math.LN10, 17840.302585092995 );
 
 
 n=0;
-test( "n=0;<BR>n +=Math.LN10", n +=Math.LN10, 2.302585092994046 ); 
+test( "n=0;<BR>n = 0-Math.LN10", n = 0-Math.LN10, -2.302585092994046 );
 
 
-n=12345; 
+n=12345;
+test( "n=12345;<BR>n = 12345-Math.LN10", n = 12345-Math.LN10, 12342.697414907006 );
+
+
+n=-12345;
+test( "n=-12345;<BR>n = -12345-Math.LN10", n = -12345-Math.LN10, -12347.302585092993 );
+
+
+n=0x45ae;
+test( "n=0x45ae;<BR>n = 17838-Math.LN10", n = 17838-Math.LN10, 17835.697414907004 );
+
+
+n=0;
+test( "n=0;<BR>n = 0*Math.LN10", n = 0*Math.LN10, 0 );
+
+
+n=12345;
+test( "n=12345;<BR>n = 12345*Math.LN10", n = 12345*Math.LN10, 28425.4129730115 );
+
+
+n=-12345;
+test( "n=-12345;<BR>n = -12345*Math.LN10", n = -12345*Math.LN10, -28425.4129730115 );
+
+
+n=0x45ae;
+test( "n=0x45ae;<BR>n = 17838*Math.LN10", n = 17838*Math.LN10, 41073.51288882779 );
+
+
+n=0;
+test( "n=0;<BR>n = 0/Math.LN10", n = 0/Math.LN10, 0 );
+
+
+n=12345;
+test( "n=12345;<BR>n = 12345/Math.LN10", n = 12345/Math.LN10, 5361.365379095643 );
+
+
+n=-12345;
+test( "n=-12345;<BR>n = -12345/Math.LN10", n = -12345/Math.LN10, -5361.365379095643 );
+
+
+n=0x45ae;
+test( "n=0x45ae;<BR>n = 17838/Math.LN10", n = 17838/Math.LN10, 7746.944968190205 );
+
+
+n=0;
+test( "n=0;<BR>n = 0%Math.LN10", n = 0%Math.LN10, 0 );
+
+
+n=12345;
+test( "n=12345;<BR>n = 12345%Math.LN10", n = 12345%Math.LN10, 0.8413164589199242 );
+
+
+n=-12345;
+test( "n=-12345;<BR>n = -12345%Math.LN10", n = -12345%Math.LN10, -0.8413164589199242 );
+
+
+n=0x45ae;
+test( "n=0x45ae;<BR>n = 17838%Math.LN10", n = 17838%Math.LN10, 2.17586966812045 );
+
+
+n=0;
+test( "n=0;<BR>n +=Math.LN10", n +=Math.LN10, 2.302585092994046 );
+
+
+n=12345;
 test( "n=12345;<BR>n +=Math.LN10", n +=Math.LN10, 12347.302585092993 );
 
 
@@ -457,10 +457,10 @@ test( "n=0x45ae;<BR>n +=Math.LN10", n +=Math.LN10, 17840.302585092995 );
 
 
 n=0;
-test( "n=0;<BR>n -=Math.LN10", n -=Math.LN10, -2.302585092994046 ); 
+test( "n=0;<BR>n -=Math.LN10", n -=Math.LN10, -2.302585092994046 );
 
 
-n=12345; 
+n=12345;
 test( "n=12345;<BR>n -=Math.LN10", n -=Math.LN10, 12342.697414907006 );
 
 
@@ -473,10 +473,10 @@ test( "n=0x45ae;<BR>n -=Math.LN10", n -=Math.LN10, 17835.697414907004 );
 
 
 n=0;
-test( "n=0;<BR>n *=Math.LN10", n *=Math.LN10, 0 ); 
+test( "n=0;<BR>n *=Math.LN10", n *=Math.LN10, 0 );
 
 
-n=12345; 
+n=12345;
 test( "n=12345;<BR>n *=Math.LN10", n *=Math.LN10, 28425.4129730115 );
 
 
@@ -489,10 +489,10 @@ test( "n=0x45ae;<BR>n *=Math.LN10", n *=Math.LN10, 41073.51288882779 );
 
 
 n=0;
-test( "n=0;<BR>n /=Math.LN10", n /=Math.LN10, 0 ); 
+test( "n=0;<BR>n /=Math.LN10", n /=Math.LN10, 0 );
 
 
-n=12345; 
+n=12345;
 test( "n=12345;<BR>n /=Math.LN10", n /=Math.LN10, 5361.365379095643 );
 
 
@@ -505,10 +505,10 @@ test( "n=0x45ae;<BR>n /=Math.LN10", n /=Math.LN10, 7746.944968190205 );
 
 
 n=0;
-test( "n=0;<BR>n %=Math.LN10", n %=Math.LN10, 0 ); 
+test( "n=0;<BR>n %=Math.LN10", n %=Math.LN10, 0 );
 
 
-n=12345; 
+n=12345;
 test( "n=12345;<BR>n %=Math.LN10", n %=Math.LN10, 0.8413164589199242 );
 
 
@@ -520,91 +520,91 @@ n=0x45ae;
 test( "n=0x45ae;<BR>n %=Math.LN10", n %=Math.LN10, 2.17586966812045 );
 
 
-n=0; 
-test( "n=0;<BR>n = 0+Math.LOG2E", n = 0+Math.LOG2E, 1.4426950408889633 ); 
+n=0;
+test( "n=0;<BR>n = 0+Math.LOG2E", n = 0+Math.LOG2E, 1.4426950408889633 );
 
 
-n=12345; 
-test( "n=12345;<BR>n = 12345+Math.LOG2E", n = 12345+Math.LOG2E, 12346.442695040888 ); 
-
-
-n=-12345;
-test( "n=-12345;<BR>n = -12345+Math.LOG2E", n = -12345+Math.LOG2E, -12343.557304959111 ); 
-
-
-n=0x45ae;
-test( "n=0x45ae;<BR>n = 17838+Math.LOG2E", n = 17838+Math.LOG2E, 17839.44269504089 ); 
-
-
-n=0; 
-test( "n=0;<BR>n = 0-Math.LOG2E", n = 0-Math.LOG2E, -1.4426950408889633 ); 
-
-
-n=12345; 
-test( "n=12345;<BR>n = 12345-Math.LOG2E", n = 12345-Math.LOG2E, 12343.557304959111 ); 
+n=12345;
+test( "n=12345;<BR>n = 12345+Math.LOG2E", n = 12345+Math.LOG2E, 12346.442695040888 );
 
 
 n=-12345;
-test( "n=-12345;<BR>n = -12345-Math.LOG2E", n = -12345-Math.LOG2E, -12346.442695040888 ); 
+test( "n=-12345;<BR>n = -12345+Math.LOG2E", n = -12345+Math.LOG2E, -12343.557304959111 );
 
 
 n=0x45ae;
-test( "n=0x45ae;<BR>n = 17838-Math.LOG2E", n = 17838-Math.LOG2E, 17836.55730495911 ); 
-
-
-n=0; 
-test( "n=0;<BR>n = 0*Math.LOG2E", n = 0*Math.LOG2E, 0 ); 
-
-
-n=12345; 
-test( "n=12345;<BR>n = 12345*Math.LOG2E", n = 12345*Math.LOG2E, 17810.070279774252 ); 
-
-
-n=-12345;
-test( "n=-12345;<BR>n = -12345*Math.LOG2E", n = -12345*Math.LOG2E, -17810.070279774252 ); 
-
-
-n=0x45ae;
-test( "n=0x45ae;<BR>n = 17838*Math.LOG2E", n = 17838*Math.LOG2E, 25734.79413937733 ); 
-
-
-n=0; 
-test( "n=0;<BR>n = 0/Math.LOG2E", n = 0/Math.LOG2E, 0 ); 
-
-
-n=12345; 
-test( "n=12345;<BR>n = 12345/Math.LOG2E", n = 12345/Math.LOG2E, 8556.901944012524 ); 
-
-
-n=-12345;
-test( "n=-12345;<BR>n = -12345/Math.LOG2E", n = -12345/Math.LOG2E, -8556.901944012524 ); 
-
-
-n=0x45ae;
-test( "n=0x45ae;<BR>n = 17838/Math.LOG2E", n = 17838/Math.LOG2E, 12364.359406828305 ); 
-
-
-n=0; 
-test( "n=0;<BR>n = 0%Math.LOG2E", n = 0%Math.LOG2E, 0 ); 
-
-
-n=12345; 
-test( "n=12345;<BR>n = 12345%Math.LOG2E", n = 12345%Math.LOG2E, 1.3012301540292607 ); 
-
-
-n=-12345;
-test( "n=-12345;<BR>n = -12345%Math.LOG2E", n = -12345%Math.LOG2E, -1.3012301540292607 ); 
-
-
-n=0x45ae;
-test( "n=0x45ae;<BR>n = 17838%Math.LOG2E", n = 17838%Math.LOG2E, 0.5185144488566831 ); 
+test( "n=0x45ae;<BR>n = 17838+Math.LOG2E", n = 17838+Math.LOG2E, 17839.44269504089 );
 
 
 n=0;
-test( "n=0;<BR>n +=Math.LOG2E", n +=Math.LOG2E, 1.4426950408889633 ); 
+test( "n=0;<BR>n = 0-Math.LOG2E", n = 0-Math.LOG2E, -1.4426950408889633 );
 
 
-n=12345; 
+n=12345;
+test( "n=12345;<BR>n = 12345-Math.LOG2E", n = 12345-Math.LOG2E, 12343.557304959111 );
+
+
+n=-12345;
+test( "n=-12345;<BR>n = -12345-Math.LOG2E", n = -12345-Math.LOG2E, -12346.442695040888 );
+
+
+n=0x45ae;
+test( "n=0x45ae;<BR>n = 17838-Math.LOG2E", n = 17838-Math.LOG2E, 17836.55730495911 );
+
+
+n=0;
+test( "n=0;<BR>n = 0*Math.LOG2E", n = 0*Math.LOG2E, 0 );
+
+
+n=12345;
+test( "n=12345;<BR>n = 12345*Math.LOG2E", n = 12345*Math.LOG2E, 17810.070279774252 );
+
+
+n=-12345;
+test( "n=-12345;<BR>n = -12345*Math.LOG2E", n = -12345*Math.LOG2E, -17810.070279774252 );
+
+
+n=0x45ae;
+test( "n=0x45ae;<BR>n = 17838*Math.LOG2E", n = 17838*Math.LOG2E, 25734.79413937733 );
+
+
+n=0;
+test( "n=0;<BR>n = 0/Math.LOG2E", n = 0/Math.LOG2E, 0 );
+
+
+n=12345;
+test( "n=12345;<BR>n = 12345/Math.LOG2E", n = 12345/Math.LOG2E, 8556.901944012524 );
+
+
+n=-12345;
+test( "n=-12345;<BR>n = -12345/Math.LOG2E", n = -12345/Math.LOG2E, -8556.901944012524 );
+
+
+n=0x45ae;
+test( "n=0x45ae;<BR>n = 17838/Math.LOG2E", n = 17838/Math.LOG2E, 12364.359406828305 );
+
+
+n=0;
+test( "n=0;<BR>n = 0%Math.LOG2E", n = 0%Math.LOG2E, 0 );
+
+
+n=12345;
+test( "n=12345;<BR>n = 12345%Math.LOG2E", n = 12345%Math.LOG2E, 1.3012301540292607 );
+
+
+n=-12345;
+test( "n=-12345;<BR>n = -12345%Math.LOG2E", n = -12345%Math.LOG2E, -1.3012301540292607 );
+
+
+n=0x45ae;
+test( "n=0x45ae;<BR>n = 17838%Math.LOG2E", n = 17838%Math.LOG2E, 0.5185144488566831 );
+
+
+n=0;
+test( "n=0;<BR>n +=Math.LOG2E", n +=Math.LOG2E, 1.4426950408889633 );
+
+
+n=12345;
 test( "n=12345;<BR>n +=Math.LOG2E", n +=Math.LOG2E, 12346.442695040888 );
 
 
@@ -617,10 +617,10 @@ test( "n=0x45ae;<BR>n +=Math.LOG2E", n +=Math.LOG2E, 17839.44269504089 );
 
 
 n=0;
-test( "n=0;<BR>n -=Math.LOG2E", n -=Math.LOG2E, -1.4426950408889633 ); 
+test( "n=0;<BR>n -=Math.LOG2E", n -=Math.LOG2E, -1.4426950408889633 );
 
 
-n=12345; 
+n=12345;
 test( "n=12345;<BR>n -=Math.LOG2E", n -=Math.LOG2E, 12343.557304959111 );
 
 
@@ -633,10 +633,10 @@ test( "n=0x45ae;<BR>n -=Math.LOG2E", n -=Math.LOG2E, 17836.55730495911 );
 
 
 n=0;
-test( "n=0;<BR>n *=Math.LOG2E", n *=Math.LOG2E, 0 ); 
+test( "n=0;<BR>n *=Math.LOG2E", n *=Math.LOG2E, 0 );
 
 
-n=12345; 
+n=12345;
 test( "n=12345;<BR>n *=Math.LOG2E", n *=Math.LOG2E, 17810.070279774252 );
 
 
@@ -649,10 +649,10 @@ test( "n=0x45ae;<BR>n *=Math.LOG2E", n *=Math.LOG2E, 25734.79413937733 );
 
 
 n=0;
-test( "n=0;<BR>n /=Math.LOG2E", n /=Math.LOG2E, 0 ); 
+test( "n=0;<BR>n /=Math.LOG2E", n /=Math.LOG2E, 0 );
 
 
-n=12345; 
+n=12345;
 test( "n=12345;<BR>n /=Math.LOG2E", n /=Math.LOG2E, 8556.901944012524 );
 
 
@@ -665,10 +665,10 @@ test( "n=0x45ae;<BR>n /=Math.LOG2E", n /=Math.LOG2E, 12364.359406828305 );
 
 
 n=0;
-test( "n=0;<BR>n %=Math.LOG2E", n %=Math.LOG2E, 0 ); 
+test( "n=0;<BR>n %=Math.LOG2E", n %=Math.LOG2E, 0 );
 
 
-n=12345; 
+n=12345;
 test( "n=12345;<BR>n %=Math.LOG2E", n %=Math.LOG2E, 1.3012301540292607 );
 
 
@@ -680,91 +680,91 @@ n=0x45ae;
 test( "n=0x45ae;<BR>n %=Math.LOG2E", n %=Math.LOG2E, 0.5185144488566831 );
 
 
-n=0; 
-test( "n=0;<BR>n = 0+Math.LOG10E", n = 0+Math.LOG10E, 0.4342944819032518 ); 
+n=0;
+test( "n=0;<BR>n = 0+Math.LOG10E", n = 0+Math.LOG10E, 0.4342944819032518 );
 
 
-n=12345; 
-test( "n=12345;<BR>n = 12345+Math.LOG10E", n = 12345+Math.LOG10E, 12345.434294481903 ); 
-
-
-n=-12345;
-test( "n=-12345;<BR>n = -12345+Math.LOG10E", n = -12345+Math.LOG10E, -12344.565705518096 ); 
-
-
-n=0x45ae;
-test( "n=0x45ae;<BR>n = 17838+Math.LOG10E", n = 17838+Math.LOG10E, 17838.434294481903 ); 
-
-
-n=0; 
-test( "n=0;<BR>n = 0-Math.LOG10E", n = 0-Math.LOG10E, -0.4342944819032518 ); 
-
-
-n=12345; 
-test( "n=12345;<BR>n = 12345-Math.LOG10E", n = 12345-Math.LOG10E, 12344.565705518096 ); 
+n=12345;
+test( "n=12345;<BR>n = 12345+Math.LOG10E", n = 12345+Math.LOG10E, 12345.434294481903 );
 
 
 n=-12345;
-test( "n=-12345;<BR>n = -12345-Math.LOG10E", n = -12345-Math.LOG10E, -12345.434294481903 ); 
+test( "n=-12345;<BR>n = -12345+Math.LOG10E", n = -12345+Math.LOG10E, -12344.565705518096 );
 
 
 n=0x45ae;
-test( "n=0x45ae;<BR>n = 17838-Math.LOG10E", n = 17838-Math.LOG10E, 17837.565705518096 ); 
-
-
-n=0; 
-test( "n=0;<BR>n = 0*Math.LOG10E", n = 0*Math.LOG10E, 0 ); 
-
-
-n=12345; 
-test( "n=12345;<BR>n = 12345*Math.LOG10E", n = 12345*Math.LOG10E, 5361.365379095644 ); 
-
-
-n=-12345;
-test( "n=-12345;<BR>n = -12345*Math.LOG10E", n = -12345*Math.LOG10E, -5361.365379095644 ); 
-
-
-n=0x45ae;
-test( "n=0x45ae;<BR>n = 17838*Math.LOG10E", n = 17838*Math.LOG10E, 7746.944968190206 ); 
-
-
-n=0; 
-test( "n=0;<BR>n = 0/Math.LOG10E", n = 0/Math.LOG10E, 0 ); 
-
-
-n=12345; 
-test( "n=12345;<BR>n = 12345/Math.LOG10E", n = 12345/Math.LOG10E, 28425.412973011494 ); 
-
-
-n=-12345;
-test( "n=-12345;<BR>n = -12345/Math.LOG10E", n = -12345/Math.LOG10E, -28425.412973011494 ); 
-
-
-n=0x45ae;
-test( "n=0x45ae;<BR>n = 17838/Math.LOG10E", n = 17838/Math.LOG10E, 41073.51288882779 ); 
-
-
-n=0; 
-test( "n=0;<BR>n = 0%Math.LOG10E", n = 0%Math.LOG10E, 0 ); 
-
-
-n=12345; 
-test( "n=12345;<BR>n = 12345%Math.LOG10E", n = 12345%Math.LOG10E, 0.17935190006711121 ); 
-
-
-n=-12345;
-test( "n=-12345;<BR>n = -12345%Math.LOG10E", n = -12345%Math.LOG10E, -0.17935190006711121 ); 
-
-
-n=0x45ae;
-test( "n=0x45ae;<BR>n = 17838%Math.LOG10E", n = 17838%Math.LOG10E, 0.222744787738134 ); 
+test( "n=0x45ae;<BR>n = 17838+Math.LOG10E", n = 17838+Math.LOG10E, 17838.434294481903 );
 
 
 n=0;
-test( "n=0;<BR>n +=Math.LOG10E", n +=Math.LOG10E, 0.4342944819032518 ); 
+test( "n=0;<BR>n = 0-Math.LOG10E", n = 0-Math.LOG10E, -0.4342944819032518 );
 
 
-n=12345; 
+n=12345;
+test( "n=12345;<BR>n = 12345-Math.LOG10E", n = 12345-Math.LOG10E, 12344.565705518096 );
+
+
+n=-12345;
+test( "n=-12345;<BR>n = -12345-Math.LOG10E", n = -12345-Math.LOG10E, -12345.434294481903 );
+
+
+n=0x45ae;
+test( "n=0x45ae;<BR>n = 17838-Math.LOG10E", n = 17838-Math.LOG10E, 17837.565705518096 );
+
+
+n=0;
+test( "n=0;<BR>n = 0*Math.LOG10E", n = 0*Math.LOG10E, 0 );
+
+
+n=12345;
+test( "n=12345;<BR>n = 12345*Math.LOG10E", n = 12345*Math.LOG10E, 5361.365379095644 );
+
+
+n=-12345;
+test( "n=-12345;<BR>n = -12345*Math.LOG10E", n = -12345*Math.LOG10E, -5361.365379095644 );
+
+
+n=0x45ae;
+test( "n=0x45ae;<BR>n = 17838*Math.LOG10E", n = 17838*Math.LOG10E, 7746.944968190206 );
+
+
+n=0;
+test( "n=0;<BR>n = 0/Math.LOG10E", n = 0/Math.LOG10E, 0 );
+
+
+n=12345;
+test( "n=12345;<BR>n = 12345/Math.LOG10E", n = 12345/Math.LOG10E, 28425.412973011494 );
+
+
+n=-12345;
+test( "n=-12345;<BR>n = -12345/Math.LOG10E", n = -12345/Math.LOG10E, -28425.412973011494 );
+
+
+n=0x45ae;
+test( "n=0x45ae;<BR>n = 17838/Math.LOG10E", n = 17838/Math.LOG10E, 41073.51288882779 );
+
+
+n=0;
+test( "n=0;<BR>n = 0%Math.LOG10E", n = 0%Math.LOG10E, 0 );
+
+
+n=12345;
+test( "n=12345;<BR>n = 12345%Math.LOG10E", n = 12345%Math.LOG10E, 0.17935190006711121 );
+
+
+n=-12345;
+test( "n=-12345;<BR>n = -12345%Math.LOG10E", n = -12345%Math.LOG10E, -0.17935190006711121 );
+
+
+n=0x45ae;
+test( "n=0x45ae;<BR>n = 17838%Math.LOG10E", n = 17838%Math.LOG10E, 0.222744787738134 );
+
+
+n=0;
+test( "n=0;<BR>n +=Math.LOG10E", n +=Math.LOG10E, 0.4342944819032518 );
+
+
+n=12345;
 test( "n=12345;<BR>n +=Math.LOG10E", n +=Math.LOG10E, 12345.434294481903 );
 
 
@@ -777,10 +777,10 @@ test( "n=0x45ae;<BR>n +=Math.LOG10E", n +=Math.LOG10E, 17838.434294481903 );
 
 
 n=0;
-test( "n=0;<BR>n -=Math.LOG10E", n -=Math.LOG10E, -0.4342944819032518 ); 
+test( "n=0;<BR>n -=Math.LOG10E", n -=Math.LOG10E, -0.4342944819032518 );
 
 
-n=12345; 
+n=12345;
 test( "n=12345;<BR>n -=Math.LOG10E", n -=Math.LOG10E, 12344.565705518096 );
 
 
@@ -793,10 +793,10 @@ test( "n=0x45ae;<BR>n -=Math.LOG10E", n -=Math.LOG10E, 17837.565705518096 );
 
 
 n=0;
-test( "n=0;<BR>n *=Math.LOG10E", n *=Math.LOG10E, 0 ); 
+test( "n=0;<BR>n *=Math.LOG10E", n *=Math.LOG10E, 0 );
 
 
-n=12345; 
+n=12345;
 test( "n=12345;<BR>n *=Math.LOG10E", n *=Math.LOG10E, 5361.365379095644 );
 
 
@@ -809,10 +809,10 @@ test( "n=0x45ae;<BR>n *=Math.LOG10E", n *=Math.LOG10E, 7746.944968190206 );
 
 
 n=0;
-test( "n=0;<BR>n /=Math.LOG10E", n /=Math.LOG10E, 0 ); 
+test( "n=0;<BR>n /=Math.LOG10E", n /=Math.LOG10E, 0 );
 
 
-n=12345; 
+n=12345;
 test( "n=12345;<BR>n /=Math.LOG10E", n /=Math.LOG10E, 28425.412973011494 );
 
 
@@ -825,10 +825,10 @@ test( "n=0x45ae;<BR>n /=Math.LOG10E", n /=Math.LOG10E, 41073.51288882779 );
 
 
 n=0;
-test( "n=0;<BR>n %=Math.LOG10E", n %=Math.LOG10E, 0 ); 
+test( "n=0;<BR>n %=Math.LOG10E", n %=Math.LOG10E, 0 );
 
 
-n=12345; 
+n=12345;
 test( "n=12345;<BR>n %=Math.LOG10E", n %=Math.LOG10E, 0.17935190006711121 );
 
 
@@ -840,91 +840,91 @@ n=0x45ae;
 test( "n=0x45ae;<BR>n %=Math.LOG10E", n %=Math.LOG10E, 0.222744787738134 );
 
 
-n=0; 
-test( "n=0;<BR>n = 0+Math.PI", n = 0+Math.PI, 3.141592653589793 ); 
+n=0;
+test( "n=0;<BR>n = 0+Math.PI", n = 0+Math.PI, 3.141592653589793 );
 
 
-n=12345; 
-test( "n=12345;<BR>n = 12345+Math.PI", n = 12345+Math.PI, 12348.14159265359 ); 
-
-
-n=-12345;
-test( "n=-12345;<BR>n = -12345+Math.PI", n = -12345+Math.PI, -12341.85840734641 ); 
-
-
-n=0x45ae;
-test( "n=0x45ae;<BR>n = 17838+Math.PI", n = 17838+Math.PI, 17841.14159265359 ); 
-
-
-n=0; 
-test( "n=0;<BR>n = 0-Math.PI", n = 0-Math.PI, -3.141592653589793 ); 
-
-
-n=12345; 
-test( "n=12345;<BR>n = 12345-Math.PI", n = 12345-Math.PI, 12341.85840734641 ); 
+n=12345;
+test( "n=12345;<BR>n = 12345+Math.PI", n = 12345+Math.PI, 12348.14159265359 );
 
 
 n=-12345;
-test( "n=-12345;<BR>n = -12345-Math.PI", n = -12345-Math.PI, -12348.14159265359 ); 
+test( "n=-12345;<BR>n = -12345+Math.PI", n = -12345+Math.PI, -12341.85840734641 );
 
 
 n=0x45ae;
-test( "n=0x45ae;<BR>n = 17838-Math.PI", n = 17838-Math.PI, 17834.85840734641 ); 
-
-
-n=0; 
-test( "n=0;<BR>n = 0*Math.PI", n = 0*Math.PI, 0 ); 
-
-
-n=12345; 
-test( "n=12345;<BR>n = 12345*Math.PI", n = 12345*Math.PI, 38782.961308565995 ); 
-
-
-n=-12345;
-test( "n=-12345;<BR>n = -12345*Math.PI", n = -12345*Math.PI, -38782.961308565995 ); 
-
-
-n=0x45ae;
-test( "n=0x45ae;<BR>n = 17838*Math.PI", n = 17838*Math.PI, 56039.729754734726 ); 
-
-
-n=0; 
-test( "n=0;<BR>n = 0/Math.PI", n = 0/Math.PI, 0 ); 
-
-
-n=12345; 
-test( "n=12345;<BR>n = 12345/Math.PI", n = 12345/Math.PI, 3929.535544938896 ); 
-
-
-n=-12345;
-test( "n=-12345;<BR>n = -12345/Math.PI", n = -12345/Math.PI, -3929.535544938896 ); 
-
-
-n=0x45ae;
-test( "n=0x45ae;<BR>n = 17838/Math.PI", n = 17838/Math.PI, 5678.011749746458 ); 
-
-
-n=0; 
-test( "n=0;<BR>n = 0%Math.PI", n = 0%Math.PI, 0 ); 
-
-
-n=12345; 
-test( "n=12345;<BR>n = 12345%Math.PI", n = 12345%Math.PI, 1.6824640457028472 ); 
-
-
-n=-12345;
-test( "n=-12345;<BR>n = -12345%Math.PI", n = -12345%Math.PI, -1.6824640457028472 ); 
-
-
-n=0x45ae;
-test( "n=0x45ae;<BR>n = 17838%Math.PI", n = 17838%Math.PI, 0.036912917154687364 ); 
+test( "n=0x45ae;<BR>n = 17838+Math.PI", n = 17838+Math.PI, 17841.14159265359 );
 
 
 n=0;
-test( "n=0;<BR>n +=Math.PI", n +=Math.PI, 3.141592653589793 ); 
+test( "n=0;<BR>n = 0-Math.PI", n = 0-Math.PI, -3.141592653589793 );
 
 
-n=12345; 
+n=12345;
+test( "n=12345;<BR>n = 12345-Math.PI", n = 12345-Math.PI, 12341.85840734641 );
+
+
+n=-12345;
+test( "n=-12345;<BR>n = -12345-Math.PI", n = -12345-Math.PI, -12348.14159265359 );
+
+
+n=0x45ae;
+test( "n=0x45ae;<BR>n = 17838-Math.PI", n = 17838-Math.PI, 17834.85840734641 );
+
+
+n=0;
+test( "n=0;<BR>n = 0*Math.PI", n = 0*Math.PI, 0 );
+
+
+n=12345;
+test( "n=12345;<BR>n = 12345*Math.PI", n = 12345*Math.PI, 38782.961308565995 );
+
+
+n=-12345;
+test( "n=-12345;<BR>n = -12345*Math.PI", n = -12345*Math.PI, -38782.961308565995 );
+
+
+n=0x45ae;
+test( "n=0x45ae;<BR>n = 17838*Math.PI", n = 17838*Math.PI, 56039.729754734726 );
+
+
+n=0;
+test( "n=0;<BR>n = 0/Math.PI", n = 0/Math.PI, 0 );
+
+
+n=12345;
+test( "n=12345;<BR>n = 12345/Math.PI", n = 12345/Math.PI, 3929.535544938896 );
+
+
+n=-12345;
+test( "n=-12345;<BR>n = -12345/Math.PI", n = -12345/Math.PI, -3929.535544938896 );
+
+
+n=0x45ae;
+test( "n=0x45ae;<BR>n = 17838/Math.PI", n = 17838/Math.PI, 5678.011749746458 );
+
+
+n=0;
+test( "n=0;<BR>n = 0%Math.PI", n = 0%Math.PI, 0 );
+
+
+n=12345;
+test( "n=12345;<BR>n = 12345%Math.PI", n = 12345%Math.PI, 1.6824640457028472 );
+
+
+n=-12345;
+test( "n=-12345;<BR>n = -12345%Math.PI", n = -12345%Math.PI, -1.6824640457028472 );
+
+
+n=0x45ae;
+test( "n=0x45ae;<BR>n = 17838%Math.PI", n = 17838%Math.PI, 0.036912917154687364 );
+
+
+n=0;
+test( "n=0;<BR>n +=Math.PI", n +=Math.PI, 3.141592653589793 );
+
+
+n=12345;
 test( "n=12345;<BR>n +=Math.PI", n +=Math.PI, 12348.14159265359 );
 
 
@@ -937,10 +937,10 @@ test( "n=0x45ae;<BR>n +=Math.PI", n +=Math.PI, 17841.14159265359 );
 
 
 n=0;
-test( "n=0;<BR>n -=Math.PI", n -=Math.PI, -3.141592653589793 ); 
+test( "n=0;<BR>n -=Math.PI", n -=Math.PI, -3.141592653589793 );
 
 
-n=12345; 
+n=12345;
 test( "n=12345;<BR>n -=Math.PI", n -=Math.PI, 12341.85840734641 );
 
 
@@ -953,10 +953,10 @@ test( "n=0x45ae;<BR>n -=Math.PI", n -=Math.PI, 17834.85840734641 );
 
 
 n=0;
-test( "n=0;<BR>n *=Math.PI", n *=Math.PI, 0 ); 
+test( "n=0;<BR>n *=Math.PI", n *=Math.PI, 0 );
 
 
-n=12345; 
+n=12345;
 test( "n=12345;<BR>n *=Math.PI", n *=Math.PI, 38782.961308565995 );
 
 
@@ -969,10 +969,10 @@ test( "n=0x45ae;<BR>n *=Math.PI", n *=Math.PI, 56039.729754734726 );
 
 
 n=0;
-test( "n=0;<BR>n /=Math.PI", n /=Math.PI, 0 ); 
+test( "n=0;<BR>n /=Math.PI", n /=Math.PI, 0 );
 
 
-n=12345; 
+n=12345;
 test( "n=12345;<BR>n /=Math.PI", n /=Math.PI, 3929.535544938896 );
 
 
@@ -985,10 +985,10 @@ test( "n=0x45ae;<BR>n /=Math.PI", n /=Math.PI, 5678.011749746458 );
 
 
 n=0;
-test( "n=0;<BR>n %=Math.PI", n %=Math.PI, 0 ); 
+test( "n=0;<BR>n %=Math.PI", n %=Math.PI, 0 );
 
 
-n=12345; 
+n=12345;
 test( "n=12345;<BR>n %=Math.PI", n %=Math.PI, 1.6824640457028472 );
 
 
@@ -1000,91 +1000,91 @@ n=0x45ae;
 test( "n=0x45ae;<BR>n %=Math.PI", n %=Math.PI, 0.036912917154687364 );
 
 
-n=0; 
-test( "n=0;<BR>n = 0+Math.SQRT1_2", n = 0+Math.SQRT1_2, 0.7071067811865476 ); 
+n=0;
+test( "n=0;<BR>n = 0+Math.SQRT1_2", n = 0+Math.SQRT1_2, 0.7071067811865476 );
 
 
-n=12345; 
-test( "n=12345;<BR>n = 12345+Math.SQRT1_2", n = 12345+Math.SQRT1_2, 12345.707106781186 ); 
-
-
-n=-12345;
-test( "n=-12345;<BR>n = -12345+Math.SQRT1_2", n = -12345+Math.SQRT1_2, -12344.292893218813 ); 
-
-
-n=0x45ae;
-test( "n=0x45ae;<BR>n = 17838+Math.SQRT1_2", n = 17838+Math.SQRT1_2, 17838.707106781185 ); 
-
-
-n=0; 
-test( "n=0;<BR>n = 0-Math.SQRT1_2", n = 0-Math.SQRT1_2, -0.7071067811865476 ); 
-
-
-n=12345; 
-test( "n=12345;<BR>n = 12345-Math.SQRT1_2", n = 12345-Math.SQRT1_2, 12344.292893218813 ); 
+n=12345;
+test( "n=12345;<BR>n = 12345+Math.SQRT1_2", n = 12345+Math.SQRT1_2, 12345.707106781186 );
 
 
 n=-12345;
-test( "n=-12345;<BR>n = -12345-Math.SQRT1_2", n = -12345-Math.SQRT1_2, -12345.707106781186 ); 
+test( "n=-12345;<BR>n = -12345+Math.SQRT1_2", n = -12345+Math.SQRT1_2, -12344.292893218813 );
 
 
 n=0x45ae;
-test( "n=0x45ae;<BR>n = 17838-Math.SQRT1_2", n = 17838-Math.SQRT1_2, 17837.292893218815 ); 
-
-
-n=0; 
-test( "n=0;<BR>n = 0*Math.SQRT1_2", n = 0*Math.SQRT1_2, 0 ); 
-
-
-n=12345; 
-test( "n=12345;<BR>n = 12345*Math.SQRT1_2", n = 12345*Math.SQRT1_2, 8729.23321374793 ); 
-
-
-n=-12345;
-test( "n=-12345;<BR>n = -12345*Math.SQRT1_2", n = -12345*Math.SQRT1_2, -8729.23321374793 ); 
-
-
-n=0x45ae;
-test( "n=0x45ae;<BR>n = 17838*Math.SQRT1_2", n = 17838*Math.SQRT1_2, 12613.370762805636 ); 
-
-
-n=0; 
-test( "n=0;<BR>n = 0/Math.SQRT1_2", n = 0/Math.SQRT1_2, 0 ); 
-
-
-n=12345; 
-test( "n=12345;<BR>n = 12345/Math.SQRT1_2", n = 12345/Math.SQRT1_2, 17458.466427495856 ); 
-
-
-n=-12345;
-test( "n=-12345;<BR>n = -12345/Math.SQRT1_2", n = -12345/Math.SQRT1_2, -17458.466427495856 ); 
-
-
-n=0x45ae;
-test( "n=0x45ae;<BR>n = 17838/Math.SQRT1_2", n = 17838/Math.SQRT1_2, 25226.74152561127 ); 
-
-
-n=0; 
-test( "n=0;<BR>n = 0%Math.SQRT1_2", n = 0%Math.SQRT1_2, 0 ); 
-
-
-n=12345; 
-test( "n=12345;<BR>n = 12345%Math.SQRT1_2", n = 12345%Math.SQRT1_2, 0.32981404525247515 ); 
-
-
-n=-12345;
-test( "n=-12345;<BR>n = -12345%Math.SQRT1_2", n = -12345%Math.SQRT1_2, -0.32981404525247515 ); 
-
-
-n=0x45ae;
-test( "n=0x45ae;<BR>n = 17838%Math.SQRT1_2", n = 17838%Math.SQRT1_2, 0.5243377881509301 ); 
+test( "n=0x45ae;<BR>n = 17838+Math.SQRT1_2", n = 17838+Math.SQRT1_2, 17838.707106781185 );
 
 
 n=0;
-test( "n=0;<BR>n +=Math.SQRT1_2", n +=Math.SQRT1_2, 0.7071067811865476 ); 
+test( "n=0;<BR>n = 0-Math.SQRT1_2", n = 0-Math.SQRT1_2, -0.7071067811865476 );
 
 
-n=12345; 
+n=12345;
+test( "n=12345;<BR>n = 12345-Math.SQRT1_2", n = 12345-Math.SQRT1_2, 12344.292893218813 );
+
+
+n=-12345;
+test( "n=-12345;<BR>n = -12345-Math.SQRT1_2", n = -12345-Math.SQRT1_2, -12345.707106781186 );
+
+
+n=0x45ae;
+test( "n=0x45ae;<BR>n = 17838-Math.SQRT1_2", n = 17838-Math.SQRT1_2, 17837.292893218815 );
+
+
+n=0;
+test( "n=0;<BR>n = 0*Math.SQRT1_2", n = 0*Math.SQRT1_2, 0 );
+
+
+n=12345;
+test( "n=12345;<BR>n = 12345*Math.SQRT1_2", n = 12345*Math.SQRT1_2, 8729.23321374793 );
+
+
+n=-12345;
+test( "n=-12345;<BR>n = -12345*Math.SQRT1_2", n = -12345*Math.SQRT1_2, -8729.23321374793 );
+
+
+n=0x45ae;
+test( "n=0x45ae;<BR>n = 17838*Math.SQRT1_2", n = 17838*Math.SQRT1_2, 12613.370762805636 );
+
+
+n=0;
+test( "n=0;<BR>n = 0/Math.SQRT1_2", n = 0/Math.SQRT1_2, 0 );
+
+
+n=12345;
+test( "n=12345;<BR>n = 12345/Math.SQRT1_2", n = 12345/Math.SQRT1_2, 17458.466427495856 );
+
+
+n=-12345;
+test( "n=-12345;<BR>n = -12345/Math.SQRT1_2", n = -12345/Math.SQRT1_2, -17458.466427495856 );
+
+
+n=0x45ae;
+test( "n=0x45ae;<BR>n = 17838/Math.SQRT1_2", n = 17838/Math.SQRT1_2, 25226.74152561127 );
+
+
+n=0;
+test( "n=0;<BR>n = 0%Math.SQRT1_2", n = 0%Math.SQRT1_2, 0 );
+
+
+n=12345;
+test( "n=12345;<BR>n = 12345%Math.SQRT1_2", n = 12345%Math.SQRT1_2, 0.32981404525247515 );
+
+
+n=-12345;
+test( "n=-12345;<BR>n = -12345%Math.SQRT1_2", n = -12345%Math.SQRT1_2, -0.32981404525247515 );
+
+
+n=0x45ae;
+test( "n=0x45ae;<BR>n = 17838%Math.SQRT1_2", n = 17838%Math.SQRT1_2, 0.5243377881509301 );
+
+
+n=0;
+test( "n=0;<BR>n +=Math.SQRT1_2", n +=Math.SQRT1_2, 0.7071067811865476 );
+
+
+n=12345;
 test( "n=12345;<BR>n +=Math.SQRT1_2", n +=Math.SQRT1_2, 12345.707106781186 );
 
 
@@ -1097,10 +1097,10 @@ test( "n=0x45ae;<BR>n +=Math.SQRT1_2", n +=Math.SQRT1_2, 17838.707106781185 );
 
 
 n=0;
-test( "n=0;<BR>n -=Math.SQRT1_2", n -=Math.SQRT1_2, -0.7071067811865476 ); 
+test( "n=0;<BR>n -=Math.SQRT1_2", n -=Math.SQRT1_2, -0.7071067811865476 );
 
 
-n=12345; 
+n=12345;
 test( "n=12345;<BR>n -=Math.SQRT1_2", n -=Math.SQRT1_2, 12344.292893218813 );
 
 
@@ -1113,10 +1113,10 @@ test( "n=0x45ae;<BR>n -=Math.SQRT1_2", n -=Math.SQRT1_2, 17837.292893218815 );
 
 
 n=0;
-test( "n=0;<BR>n *=Math.SQRT1_2", n *=Math.SQRT1_2, 0 ); 
+test( "n=0;<BR>n *=Math.SQRT1_2", n *=Math.SQRT1_2, 0 );
 
 
-n=12345; 
+n=12345;
 test( "n=12345;<BR>n *=Math.SQRT1_2", n *=Math.SQRT1_2, 8729.23321374793 );
 
 
@@ -1129,10 +1129,10 @@ test( "n=0x45ae;<BR>n *=Math.SQRT1_2", n *=Math.SQRT1_2, 12613.370762805636 );
 
 
 n=0;
-test( "n=0;<BR>n /=Math.SQRT1_2", n /=Math.SQRT1_2, 0 ); 
+test( "n=0;<BR>n /=Math.SQRT1_2", n /=Math.SQRT1_2, 0 );
 
 
-n=12345; 
+n=12345;
 test( "n=12345;<BR>n /=Math.SQRT1_2", n /=Math.SQRT1_2, 17458.466427495856 );
 
 
@@ -1145,10 +1145,10 @@ test( "n=0x45ae;<BR>n /=Math.SQRT1_2", n /=Math.SQRT1_2, 25226.74152561127 );
 
 
 n=0;
-test( "n=0;<BR>n %=Math.SQRT1_2", n %=Math.SQRT1_2, 0 ); 
+test( "n=0;<BR>n %=Math.SQRT1_2", n %=Math.SQRT1_2, 0 );
 
 
-n=12345; 
+n=12345;
 test( "n=12345;<BR>n %=Math.SQRT1_2", n %=Math.SQRT1_2, 0.32981404525247515 );
 
 
@@ -1160,91 +1160,91 @@ n=0x45ae;
 test( "n=0x45ae;<BR>n %=Math.SQRT1_2", n %=Math.SQRT1_2, 0.5243377881509301 );
 
 
-n=0; 
-test( "n=0;<BR>n = 0+Math.SQRT2", n = 0+Math.SQRT2, 1.4142135623730951 ); 
+n=0;
+test( "n=0;<BR>n = 0+Math.SQRT2", n = 0+Math.SQRT2, 1.4142135623730951 );
 
 
-n=12345; 
-test( "n=12345;<BR>n = 12345+Math.SQRT2", n = 12345+Math.SQRT2, 12346.414213562373 ); 
-
-
-n=-12345;
-test( "n=-12345;<BR>n = -12345+Math.SQRT2", n = -12345+Math.SQRT2, -12343.585786437626 ); 
-
-
-n=0x45ae;
-test( "n=0x45ae;<BR>n = 17838+Math.SQRT2", n = 17838+Math.SQRT2, 17839.414213562373 ); 
-
-
-n=0; 
-test( "n=0;<BR>n = 0-Math.SQRT2", n = 0-Math.SQRT2, -1.4142135623730951 ); 
-
-
-n=12345; 
-test( "n=12345;<BR>n = 12345-Math.SQRT2", n = 12345-Math.SQRT2, 12343.585786437626 ); 
+n=12345;
+test( "n=12345;<BR>n = 12345+Math.SQRT2", n = 12345+Math.SQRT2, 12346.414213562373 );
 
 
 n=-12345;
-test( "n=-12345;<BR>n = -12345-Math.SQRT2", n = -12345-Math.SQRT2, -12346.414213562373 ); 
+test( "n=-12345;<BR>n = -12345+Math.SQRT2", n = -12345+Math.SQRT2, -12343.585786437626 );
 
 
 n=0x45ae;
-test( "n=0x45ae;<BR>n = 17838-Math.SQRT2", n = 17838-Math.SQRT2, 17836.585786437626 ); 
-
-
-n=0; 
-test( "n=0;<BR>n = 0*Math.SQRT2", n = 0*Math.SQRT2, 0 ); 
-
-
-n=12345; 
-test( "n=12345;<BR>n = 12345*Math.SQRT2", n = 12345*Math.SQRT2, 17458.46642749586 ); 
-
-
-n=-12345;
-test( "n=-12345;<BR>n = -12345*Math.SQRT2", n = -12345*Math.SQRT2, -17458.46642749586 ); 
-
-
-n=0x45ae;
-test( "n=0x45ae;<BR>n = 17838*Math.SQRT2", n = 17838*Math.SQRT2, 25226.741525611272 ); 
-
-
-n=0; 
-test( "n=0;<BR>n = 0/Math.SQRT2", n = 0/Math.SQRT2, 0 ); 
-
-
-n=12345; 
-test( "n=12345;<BR>n = 12345/Math.SQRT2", n = 12345/Math.SQRT2, 8729.233213747928 ); 
-
-
-n=-12345;
-test( "n=-12345;<BR>n = -12345/Math.SQRT2", n = -12345/Math.SQRT2, -8729.233213747928 ); 
-
-
-n=0x45ae;
-test( "n=0x45ae;<BR>n = 17838/Math.SQRT2", n = 17838/Math.SQRT2, 12613.370762805634 ); 
-
-
-n=0; 
-test( "n=0;<BR>n = 0%Math.SQRT2", n = 0%Math.SQRT2, 0 ); 
-
-
-n=12345; 
-test( "n=12345;<BR>n = 12345%Math.SQRT2", n = 12345%Math.SQRT2, 0.32981404525247515 ); 
-
-
-n=-12345;
-test( "n=-12345;<BR>n = -12345%Math.SQRT2", n = -12345%Math.SQRT2, -0.32981404525247515 ); 
-
-
-n=0x45ae;
-test( "n=0x45ae;<BR>n = 17838%Math.SQRT2", n = 17838%Math.SQRT2, 0.5243377881509301 ); 
+test( "n=0x45ae;<BR>n = 17838+Math.SQRT2", n = 17838+Math.SQRT2, 17839.414213562373 );
 
 
 n=0;
-test( "n=0;<BR>n +=Math.SQRT2", n +=Math.SQRT2, 1.4142135623730951 ); 
+test( "n=0;<BR>n = 0-Math.SQRT2", n = 0-Math.SQRT2, -1.4142135623730951 );
 
 
-n=12345; 
+n=12345;
+test( "n=12345;<BR>n = 12345-Math.SQRT2", n = 12345-Math.SQRT2, 12343.585786437626 );
+
+
+n=-12345;
+test( "n=-12345;<BR>n = -12345-Math.SQRT2", n = -12345-Math.SQRT2, -12346.414213562373 );
+
+
+n=0x45ae;
+test( "n=0x45ae;<BR>n = 17838-Math.SQRT2", n = 17838-Math.SQRT2, 17836.585786437626 );
+
+
+n=0;
+test( "n=0;<BR>n = 0*Math.SQRT2", n = 0*Math.SQRT2, 0 );
+
+
+n=12345;
+test( "n=12345;<BR>n = 12345*Math.SQRT2", n = 12345*Math.SQRT2, 17458.46642749586 );
+
+
+n=-12345;
+test( "n=-12345;<BR>n = -12345*Math.SQRT2", n = -12345*Math.SQRT2, -17458.46642749586 );
+
+
+n=0x45ae;
+test( "n=0x45ae;<BR>n = 17838*Math.SQRT2", n = 17838*Math.SQRT2, 25226.741525611272 );
+
+
+n=0;
+test( "n=0;<BR>n = 0/Math.SQRT2", n = 0/Math.SQRT2, 0 );
+
+
+n=12345;
+test( "n=12345;<BR>n = 12345/Math.SQRT2", n = 12345/Math.SQRT2, 8729.233213747928 );
+
+
+n=-12345;
+test( "n=-12345;<BR>n = -12345/Math.SQRT2", n = -12345/Math.SQRT2, -8729.233213747928 );
+
+
+n=0x45ae;
+test( "n=0x45ae;<BR>n = 17838/Math.SQRT2", n = 17838/Math.SQRT2, 12613.370762805634 );
+
+
+n=0;
+test( "n=0;<BR>n = 0%Math.SQRT2", n = 0%Math.SQRT2, 0 );
+
+
+n=12345;
+test( "n=12345;<BR>n = 12345%Math.SQRT2", n = 12345%Math.SQRT2, 0.32981404525247515 );
+
+
+n=-12345;
+test( "n=-12345;<BR>n = -12345%Math.SQRT2", n = -12345%Math.SQRT2, -0.32981404525247515 );
+
+
+n=0x45ae;
+test( "n=0x45ae;<BR>n = 17838%Math.SQRT2", n = 17838%Math.SQRT2, 0.5243377881509301 );
+
+
+n=0;
+test( "n=0;<BR>n +=Math.SQRT2", n +=Math.SQRT2, 1.4142135623730951 );
+
+
+n=12345;
 test( "n=12345;<BR>n +=Math.SQRT2", n +=Math.SQRT2, 12346.414213562373 );
 
 
@@ -1257,10 +1257,10 @@ test( "n=0x45ae;<BR>n +=Math.SQRT2", n +=Math.SQRT2, 17839.414213562373 );
 
 
 n=0;
-test( "n=0;<BR>n -=Math.SQRT2", n -=Math.SQRT2, -1.4142135623730951 ); 
+test( "n=0;<BR>n -=Math.SQRT2", n -=Math.SQRT2, -1.4142135623730951 );
 
 
-n=12345; 
+n=12345;
 test( "n=12345;<BR>n -=Math.SQRT2", n -=Math.SQRT2, 12343.585786437626 );
 
 
@@ -1273,10 +1273,10 @@ test( "n=0x45ae;<BR>n -=Math.SQRT2", n -=Math.SQRT2, 17836.585786437626 );
 
 
 n=0;
-test( "n=0;<BR>n *=Math.SQRT2", n *=Math.SQRT2, 0 ); 
+test( "n=0;<BR>n *=Math.SQRT2", n *=Math.SQRT2, 0 );
 
 
-n=12345; 
+n=12345;
 test( "n=12345;<BR>n *=Math.SQRT2", n *=Math.SQRT2, 17458.46642749586 );
 
 
@@ -1289,10 +1289,10 @@ test( "n=0x45ae;<BR>n *=Math.SQRT2", n *=Math.SQRT2, 25226.741525611272 );
 
 
 n=0;
-test( "n=0;<BR>n /=Math.SQRT2", n /=Math.SQRT2, 0 ); 
+test( "n=0;<BR>n /=Math.SQRT2", n /=Math.SQRT2, 0 );
 
 
-n=12345; 
+n=12345;
 test( "n=12345;<BR>n /=Math.SQRT2", n /=Math.SQRT2, 8729.233213747928 );
 
 
@@ -1305,10 +1305,10 @@ test( "n=0x45ae;<BR>n /=Math.SQRT2", n /=Math.SQRT2, 12613.370762805634 );
 
 
 n=0;
-test( "n=0;<BR>n %=Math.SQRT2", n %=Math.SQRT2, 0 ); 
+test( "n=0;<BR>n %=Math.SQRT2", n %=Math.SQRT2, 0 );
 
 
-n=12345; 
+n=12345;
 test( "n=12345;<BR>n %=Math.SQRT2", n %=Math.SQRT2, 0.32981404525247515 );
 
 
@@ -1320,94 +1320,94 @@ n=0x45ae;
 test( "n=0x45ae;<BR>n %=Math.SQRT2", n %=Math.SQRT2, 0.5243377881509301 );
 
 
-n=0; 
-test( "n=0;<BR>n = 0+Number.POSITIVE_INFINITY", n = 0+Number.POSITIVE_INFINITY, Infinity ); 
+n=0;
+test( "n=0;<BR>n = 0+Number.POSITIVE_INFINITY", n = 0+Number.POSITIVE_INFINITY, Infinity );
 
 
-n=12345; 
-test( "n=12345;<BR>n = 12345+Number.POSITIVE_INFINITY", n = 12345+Number.POSITIVE_INFINITY, Infinity ); 
-
-
-n=-12345;
-test( "n=-12345;<BR>n = -12345+Number.POSITIVE_INFINITY", n = -12345+Number.POSITIVE_INFINITY, Infinity ); 
-
-
-n=0x45ae;
-test( "n=0x45ae;<BR>n = 17838+Number.POSITIVE_INFINITY", n = 17838+Number.POSITIVE_INFINITY, Infinity ); 
-
-
-n=0; 
-test( "n=0;<BR>n = 0-Number.POSITIVE_INFINITY", n = 0-Number.POSITIVE_INFINITY, -Infinity ); 
-
-
-n=12345; 
-test( "n=12345;<BR>n = 12345-Number.POSITIVE_INFINITY", n = 12345-Number.POSITIVE_INFINITY, -Infinity ); 
+n=12345;
+test( "n=12345;<BR>n = 12345+Number.POSITIVE_INFINITY", n = 12345+Number.POSITIVE_INFINITY, Infinity );
 
 
 n=-12345;
-test( "n=-12345;<BR>n = -12345-Number.POSITIVE_INFINITY", n = -12345-Number.POSITIVE_INFINITY, -Infinity ); 
+test( "n=-12345;<BR>n = -12345+Number.POSITIVE_INFINITY", n = -12345+Number.POSITIVE_INFINITY, Infinity );
 
 
 n=0x45ae;
-test( "n=0x45ae;<BR>n = 17838-Number.POSITIVE_INFINITY", n = 17838-Number.POSITIVE_INFINITY, -Infinity ); 
+test( "n=0x45ae;<BR>n = 17838+Number.POSITIVE_INFINITY", n = 17838+Number.POSITIVE_INFINITY, Infinity );
 
 
-n=0; 
-test( "n=0;<BR>n = 0*Number.POSITIVE_INFINITY", n = 0*Number.POSITIVE_INFINITY, Number.NaN ); 
+n=0;
+test( "n=0;<BR>n = 0-Number.POSITIVE_INFINITY", n = 0-Number.POSITIVE_INFINITY, -Infinity );
 
 
-n=12345; 
-test( "n=12345;<BR>n = 12345*Number.POSITIVE_INFINITY", n = 12345*Number.POSITIVE_INFINITY, Infinity ); 
+n=12345;
+test( "n=12345;<BR>n = 12345-Number.POSITIVE_INFINITY", n = 12345-Number.POSITIVE_INFINITY, -Infinity );
 
 
 n=-12345;
-test( "n=-12345;<BR>n = -12345*Number.POSITIVE_INFINITY", n = -12345*Number.POSITIVE_INFINITY, -Infinity ); 
+test( "n=-12345;<BR>n = -12345-Number.POSITIVE_INFINITY", n = -12345-Number.POSITIVE_INFINITY, -Infinity );
 
 
 n=0x45ae;
-test( "n=0x45ae;<BR>n = 17838*Number.POSITIVE_INFINITY", n = 17838*Number.POSITIVE_INFINITY, Infinity ); 
+test( "n=0x45ae;<BR>n = 17838-Number.POSITIVE_INFINITY", n = 17838-Number.POSITIVE_INFINITY, -Infinity );
 
 
-n=0; 
-test( "n=0;<BR>n = 0/Number.POSITIVE_INFINITY", n = 0/Number.POSITIVE_INFINITY, 0 ); 
+n=0;
+test( "n=0;<BR>n = 0*Number.POSITIVE_INFINITY", n = 0*Number.POSITIVE_INFINITY, Number.NaN );
 
 
-n=12345; 
-test( "n=12345;<BR>n = 12345/Number.POSITIVE_INFINITY", n = 12345/Number.POSITIVE_INFINITY, 0 ); 
+n=12345;
+test( "n=12345;<BR>n = 12345*Number.POSITIVE_INFINITY", n = 12345*Number.POSITIVE_INFINITY, Infinity );
 
 
 n=-12345;
-test( "n=-12345;<BR>n = -12345/Number.POSITIVE_INFINITY", n = -12345/Number.POSITIVE_INFINITY, 0 ); 
+test( "n=-12345;<BR>n = -12345*Number.POSITIVE_INFINITY", n = -12345*Number.POSITIVE_INFINITY, -Infinity );
 
 
 n=0x45ae;
-test( "n=0x45ae;<BR>n = 17838/Number.POSITIVE_INFINITY", n = 17838/Number.POSITIVE_INFINITY, 0 ); 
+test( "n=0x45ae;<BR>n = 17838*Number.POSITIVE_INFINITY", n = 17838*Number.POSITIVE_INFINITY, Infinity );
 
 
-n=0; 
-test( "n=0;<BR>n = 0%Number.POSITIVE_INFINITY", n = 0%Number.POSITIVE_INFINITY, 0 ); 
+n=0;
+test( "n=0;<BR>n = 0/Number.POSITIVE_INFINITY", n = 0/Number.POSITIVE_INFINITY, 0 );
+
+
+n=12345;
+test( "n=12345;<BR>n = 12345/Number.POSITIVE_INFINITY", n = 12345/Number.POSITIVE_INFINITY, 0 );
+
+
+n=-12345;
+test( "n=-12345;<BR>n = -12345/Number.POSITIVE_INFINITY", n = -12345/Number.POSITIVE_INFINITY, 0 );
+
+
+n=0x45ae;
+test( "n=0x45ae;<BR>n = 17838/Number.POSITIVE_INFINITY", n = 17838/Number.POSITIVE_INFINITY, 0 );
+
+
+n=0;
+test( "n=0;<BR>n = 0%Number.POSITIVE_INFINITY", n = 0%Number.POSITIVE_INFINITY, 0 );
 /* ECMA spec:
 * If the dividend is finite and the divisor is an infinity, the result equals the dividend.
 * If the dividend is a zero and the divisor is finite, the result is the same as the dividend.
 */
 
-n=12345; 
-test( "n=12345;<BR>n = 12345%Number.POSITIVE_INFINITY", n = 12345%Number.POSITIVE_INFINITY, 12345 ); 
+n=12345;
+test( "n=12345;<BR>n = 12345%Number.POSITIVE_INFINITY", n = 12345%Number.POSITIVE_INFINITY, 12345 );
 
 
 n=-12345;
-test( "n=-12345;<BR>n = -12345%Number.POSITIVE_INFINITY", n = -12345%Number.POSITIVE_INFINITY, -12345 ); 
+test( "n=-12345;<BR>n = -12345%Number.POSITIVE_INFINITY", n = -12345%Number.POSITIVE_INFINITY, -12345 );
 
 
 n=0x45ae;
-test( "n=0x45ae;<BR>n = 17838%Number.POSITIVE_INFINITY", n = 17838%Number.POSITIVE_INFINITY, 17838 ); 
+test( "n=0x45ae;<BR>n = 17838%Number.POSITIVE_INFINITY", n = 17838%Number.POSITIVE_INFINITY, 17838 );
 
 
 n=0;
-test( "n=0;<BR>n +=Number.POSITIVE_INFINITY", n +=Number.POSITIVE_INFINITY, Infinity ); 
+test( "n=0;<BR>n +=Number.POSITIVE_INFINITY", n +=Number.POSITIVE_INFINITY, Infinity );
 
 
-n=12345; 
+n=12345;
 test( "n=12345;<BR>n +=Number.POSITIVE_INFINITY", n +=Number.POSITIVE_INFINITY, Infinity );
 
 
@@ -1420,10 +1420,10 @@ test( "n=0x45ae;<BR>n +=Number.POSITIVE_INFINITY", n +=Number.POSITIVE_INFINITY,
 
 
 n=0;
-test( "n=0;<BR>n -=Number.POSITIVE_INFINITY", n -=Number.POSITIVE_INFINITY, -Infinity ); 
+test( "n=0;<BR>n -=Number.POSITIVE_INFINITY", n -=Number.POSITIVE_INFINITY, -Infinity );
 
 
-n=12345; 
+n=12345;
 test( "n=12345;<BR>n -=Number.POSITIVE_INFINITY", n -=Number.POSITIVE_INFINITY, -Infinity );
 
 
@@ -1436,10 +1436,10 @@ test( "n=0x45ae;<BR>n -=Number.POSITIVE_INFINITY", n -=Number.POSITIVE_INFINITY,
 
 
 n=0;
-test( "n=0;<BR>n *=Number.POSITIVE_INFINITY", n *=Number.POSITIVE_INFINITY, Number.NaN ); 
+test( "n=0;<BR>n *=Number.POSITIVE_INFINITY", n *=Number.POSITIVE_INFINITY, Number.NaN );
 
 
-n=12345; 
+n=12345;
 test( "n=12345;<BR>n *=Number.POSITIVE_INFINITY", n *=Number.POSITIVE_INFINITY, Infinity );
 
 
@@ -1452,10 +1452,10 @@ test( "n=0x45ae;<BR>n *=Number.POSITIVE_INFINITY", n *=Number.POSITIVE_INFINITY,
 
 
 n=0;
-test( "n=0;<BR>n /=Number.POSITIVE_INFINITY", n /=Number.POSITIVE_INFINITY, 0 ); 
+test( "n=0;<BR>n /=Number.POSITIVE_INFINITY", n /=Number.POSITIVE_INFINITY, 0 );
 
 
-n=12345; 
+n=12345;
 test( "n=12345;<BR>n /=Number.POSITIVE_INFINITY", n /=Number.POSITIVE_INFINITY, 0 );
 
 
@@ -1468,10 +1468,10 @@ test( "n=0x45ae;<BR>n /=Number.POSITIVE_INFINITY", n /=Number.POSITIVE_INFINITY,
 
 
 n=0;
-test( "n=0;<BR>n %=Number.POSITIVE_INFINITY", n %=Number.POSITIVE_INFINITY, 0 ); 
+test( "n=0;<BR>n %=Number.POSITIVE_INFINITY", n %=Number.POSITIVE_INFINITY, 0 );
 
 
-n=12345; 
+n=12345;
 test( "n=12345;<BR>n %=Number.POSITIVE_INFINITY", n %=Number.POSITIVE_INFINITY, 12345 );
 
 
@@ -1483,91 +1483,91 @@ n=0x45ae;
 test( "n=0x45ae;<BR>n %=Number.POSITIVE_INFINITY", n %=Number.POSITIVE_INFINITY, 17838 );
 
 
-n=0; 
-test( "n=0;<BR>n = 0+Number.NEGATIVE_INFINITY", n = 0+Number.NEGATIVE_INFINITY, -Infinity ); 
+n=0;
+test( "n=0;<BR>n = 0+Number.NEGATIVE_INFINITY", n = 0+Number.NEGATIVE_INFINITY, -Infinity );
 
 
-n=12345; 
-test( "n=12345;<BR>n = 12345+Number.NEGATIVE_INFINITY", n = 12345+Number.NEGATIVE_INFINITY, -Infinity ); 
-
-
-n=-12345;
-test( "n=-12345;<BR>n = -12345+Number.NEGATIVE_INFINITY", n = -12345+Number.NEGATIVE_INFINITY, -Infinity ); 
-
-
-n=0x45ae;
-test( "n=0x45ae;<BR>n = 17838+Number.NEGATIVE_INFINITY", n = 17838+Number.NEGATIVE_INFINITY, -Infinity ); 
-
-
-n=0; 
-test( "n=0;<BR>n = 0-Number.NEGATIVE_INFINITY", n = 0-Number.NEGATIVE_INFINITY, Infinity ); 
-
-
-n=12345; 
-test( "n=12345;<BR>n = 12345-Number.NEGATIVE_INFINITY", n = 12345-Number.NEGATIVE_INFINITY, Infinity ); 
+n=12345;
+test( "n=12345;<BR>n = 12345+Number.NEGATIVE_INFINITY", n = 12345+Number.NEGATIVE_INFINITY, -Infinity );
 
 
 n=-12345;
-test( "n=-12345;<BR>n = -12345-Number.NEGATIVE_INFINITY", n = -12345-Number.NEGATIVE_INFINITY, Infinity ); 
+test( "n=-12345;<BR>n = -12345+Number.NEGATIVE_INFINITY", n = -12345+Number.NEGATIVE_INFINITY, -Infinity );
 
 
 n=0x45ae;
-test( "n=0x45ae;<BR>n = 17838-Number.NEGATIVE_INFINITY", n = 17838-Number.NEGATIVE_INFINITY, Infinity ); 
-
-
-n=0; 
-test( "n=0;<BR>n = 0*Number.NEGATIVE_INFINITY", n = 0*Number.NEGATIVE_INFINITY, Number.NaN ); 
-
-
-n=12345; 
-test( "n=12345;<BR>n = 12345*Number.NEGATIVE_INFINITY", n = 12345*Number.NEGATIVE_INFINITY, -Infinity ); 
-
-
-n=-12345;
-test( "n=-12345;<BR>n = -12345*Number.NEGATIVE_INFINITY", n = -12345*Number.NEGATIVE_INFINITY, Infinity ); 
-
-
-n=0x45ae;
-test( "n=0x45ae;<BR>n = 17838*Number.NEGATIVE_INFINITY", n = 17838*Number.NEGATIVE_INFINITY, -Infinity ); 
-
-
-n=0; 
-test( "n=0;<BR>n = 0/Number.NEGATIVE_INFINITY", n = 0/Number.NEGATIVE_INFINITY, 0 ); 
-
-
-n=12345; 
-test( "n=12345;<BR>n = 12345/Number.NEGATIVE_INFINITY", n = 12345/Number.NEGATIVE_INFINITY, 0 ); 
-
-
-n=-12345;
-test( "n=-12345;<BR>n = -12345/Number.NEGATIVE_INFINITY", n = -12345/Number.NEGATIVE_INFINITY, 0 ); 
-
-
-n=0x45ae;
-test( "n=0x45ae;<BR>n = 17838/Number.NEGATIVE_INFINITY", n = 17838/Number.NEGATIVE_INFINITY, 0 ); 
-
-
-n=0; 
-test( "n=0;<BR>n = 0%Number.NEGATIVE_INFINITY", n = 0%Number.NEGATIVE_INFINITY, 0 ); 
-
-
-n=12345; 
-test( "n=12345;<BR>n = 12345%Number.NEGATIVE_INFINITY", n = 12345%Number.NEGATIVE_INFINITY, 12345 ); 
-
-
-n=-12345;
-test( "n=-12345;<BR>n = -12345%Number.NEGATIVE_INFINITY", n = -12345%Number.NEGATIVE_INFINITY, -12345 ); 
-
-
-n=0x45ae;
-test( "n=0x45ae;<BR>n = 17838%Number.NEGATIVE_INFINITY", n = 17838%Number.NEGATIVE_INFINITY, 17838 ); 
+test( "n=0x45ae;<BR>n = 17838+Number.NEGATIVE_INFINITY", n = 17838+Number.NEGATIVE_INFINITY, -Infinity );
 
 
 n=0;
-test( "n=0;<BR>n +=Number.NEGATIVE_INFINITY", n +=Number.NEGATIVE_INFINITY, -Infinity ); 
+test( "n=0;<BR>n = 0-Number.NEGATIVE_INFINITY", n = 0-Number.NEGATIVE_INFINITY, Infinity );
 
 
-n=12345; 
+n=12345;
+test( "n=12345;<BR>n = 12345-Number.NEGATIVE_INFINITY", n = 12345-Number.NEGATIVE_INFINITY, Infinity );
+
+
+n=-12345;
+test( "n=-12345;<BR>n = -12345-Number.NEGATIVE_INFINITY", n = -12345-Number.NEGATIVE_INFINITY, Infinity );
+
+
+n=0x45ae;
+test( "n=0x45ae;<BR>n = 17838-Number.NEGATIVE_INFINITY", n = 17838-Number.NEGATIVE_INFINITY, Infinity );
+
+
+n=0;
+test( "n=0;<BR>n = 0*Number.NEGATIVE_INFINITY", n = 0*Number.NEGATIVE_INFINITY, Number.NaN );
+
+
+n=12345;
+test( "n=12345;<BR>n = 12345*Number.NEGATIVE_INFINITY", n = 12345*Number.NEGATIVE_INFINITY, -Infinity );
+
+
+n=-12345;
+test( "n=-12345;<BR>n = -12345*Number.NEGATIVE_INFINITY", n = -12345*Number.NEGATIVE_INFINITY, Infinity );
+
+
+n=0x45ae;
+test( "n=0x45ae;<BR>n = 17838*Number.NEGATIVE_INFINITY", n = 17838*Number.NEGATIVE_INFINITY, -Infinity );
+
+
+n=0;
+test( "n=0;<BR>n = 0/Number.NEGATIVE_INFINITY", n = 0/Number.NEGATIVE_INFINITY, 0 );
+
+
+n=12345;
+test( "n=12345;<BR>n = 12345/Number.NEGATIVE_INFINITY", n = 12345/Number.NEGATIVE_INFINITY, 0 );
+
+
+n=-12345;
+test( "n=-12345;<BR>n = -12345/Number.NEGATIVE_INFINITY", n = -12345/Number.NEGATIVE_INFINITY, 0 );
+
+
+n=0x45ae;
+test( "n=0x45ae;<BR>n = 17838/Number.NEGATIVE_INFINITY", n = 17838/Number.NEGATIVE_INFINITY, 0 );
+
+
+n=0;
+test( "n=0;<BR>n = 0%Number.NEGATIVE_INFINITY", n = 0%Number.NEGATIVE_INFINITY, 0 );
+
+
+n=12345;
+test( "n=12345;<BR>n = 12345%Number.NEGATIVE_INFINITY", n = 12345%Number.NEGATIVE_INFINITY, 12345 );
+
+
+n=-12345;
+test( "n=-12345;<BR>n = -12345%Number.NEGATIVE_INFINITY", n = -12345%Number.NEGATIVE_INFINITY, -12345 );
+
+
+n=0x45ae;
+test( "n=0x45ae;<BR>n = 17838%Number.NEGATIVE_INFINITY", n = 17838%Number.NEGATIVE_INFINITY, 17838 );
+
+
+n=0;
+test( "n=0;<BR>n +=Number.NEGATIVE_INFINITY", n +=Number.NEGATIVE_INFINITY, -Infinity );
+
+
+n=12345;
 test( "n=12345;<BR>n +=Number.NEGATIVE_INFINITY", n +=Number.NEGATIVE_INFINITY, -Infinity );
 
 
@@ -1580,10 +1580,10 @@ test( "n=0x45ae;<BR>n +=Number.NEGATIVE_INFINITY", n +=Number.NEGATIVE_INFINITY,
 
 
 n=0;
-test( "n=0;<BR>n -=Number.NEGATIVE_INFINITY", n -=Number.NEGATIVE_INFINITY, Infinity ); 
+test( "n=0;<BR>n -=Number.NEGATIVE_INFINITY", n -=Number.NEGATIVE_INFINITY, Infinity );
 
 
-n=12345; 
+n=12345;
 test( "n=12345;<BR>n -=Number.NEGATIVE_INFINITY", n -=Number.NEGATIVE_INFINITY, Infinity );
 
 
@@ -1596,10 +1596,10 @@ test( "n=0x45ae;<BR>n -=Number.NEGATIVE_INFINITY", n -=Number.NEGATIVE_INFINITY,
 
 
 n=0;
-test( "n=0;<BR>n *=Number.NEGATIVE_INFINITY", n *=Number.NEGATIVE_INFINITY, Number.NaN ); 
+test( "n=0;<BR>n *=Number.NEGATIVE_INFINITY", n *=Number.NEGATIVE_INFINITY, Number.NaN );
 
 
-n=12345; 
+n=12345;
 test( "n=12345;<BR>n *=Number.NEGATIVE_INFINITY", n *=Number.NEGATIVE_INFINITY, -Infinity );
 
 
@@ -1612,10 +1612,10 @@ test( "n=0x45ae;<BR>n *=Number.NEGATIVE_INFINITY", n *=Number.NEGATIVE_INFINITY,
 
 
 n=0;
-test( "n=0;<BR>n /=Number.NEGATIVE_INFINITY", n /=Number.NEGATIVE_INFINITY, 0 ); 
+test( "n=0;<BR>n /=Number.NEGATIVE_INFINITY", n /=Number.NEGATIVE_INFINITY, 0 );
 
 
-n=12345; 
+n=12345;
 test( "n=12345;<BR>n /=Number.NEGATIVE_INFINITY", n /=Number.NEGATIVE_INFINITY, 0 );
 
 
@@ -1628,10 +1628,10 @@ test( "n=0x45ae;<BR>n /=Number.NEGATIVE_INFINITY", n /=Number.NEGATIVE_INFINITY,
 
 
 n=0;
-test( "n=0;<BR>n %=Number.NEGATIVE_INFINITY", n %=Number.NEGATIVE_INFINITY, 0 ); 
+test( "n=0;<BR>n %=Number.NEGATIVE_INFINITY", n %=Number.NEGATIVE_INFINITY, 0 );
 
 
-n=12345; 
+n=12345;
 test( "n=12345;<BR>n %=Number.NEGATIVE_INFINITY", n %=Number.NEGATIVE_INFINITY, 12345 );
 
 
@@ -1643,91 +1643,91 @@ n=0x45ae;
 test( "n=0x45ae;<BR>n %=Number.NEGATIVE_INFINITY", n %=Number.NEGATIVE_INFINITY, 17838 );
 
 
-n=0; 
-test( "n=0;<BR>n = 0+Number.MAX_VALUE", n = 0+Number.MAX_VALUE, 1.7976931348623157e+308 ); 
+n=0;
+test( "n=0;<BR>n = 0+Number.MAX_VALUE", n = 0+Number.MAX_VALUE, 1.7976931348623157e+308 );
 
 
-n=12345; 
-test( "n=12345;<BR>n = 12345+Number.MAX_VALUE", n = 12345+Number.MAX_VALUE, 1.7976931348623157e+308 ); 
-
-
-n=-12345;
-test( "n=-12345;<BR>n = -12345+Number.MAX_VALUE", n = -12345+Number.MAX_VALUE, 1.7976931348623157e+308 ); 
-
-
-n=0x45ae;
-test( "n=0x45ae;<BR>n = 17838+Number.MAX_VALUE", n = 17838+Number.MAX_VALUE, 1.7976931348623157e+308 ); 
-
-
-n=0; 
-test( "n=0;<BR>n = 0-Number.MAX_VALUE", n = 0-Number.MAX_VALUE, -1.7976931348623157e+308 ); 
-
-
-n=12345; 
-test( "n=12345;<BR>n = 12345-Number.MAX_VALUE", n = 12345-Number.MAX_VALUE, -1.7976931348623157e+308 ); 
+n=12345;
+test( "n=12345;<BR>n = 12345+Number.MAX_VALUE", n = 12345+Number.MAX_VALUE, 1.7976931348623157e+308 );
 
 
 n=-12345;
-test( "n=-12345;<BR>n = -12345-Number.MAX_VALUE", n = -12345-Number.MAX_VALUE, -1.7976931348623157e+308 ); 
+test( "n=-12345;<BR>n = -12345+Number.MAX_VALUE", n = -12345+Number.MAX_VALUE, 1.7976931348623157e+308 );
 
 
 n=0x45ae;
-test( "n=0x45ae;<BR>n = 17838-Number.MAX_VALUE", n = 17838-Number.MAX_VALUE, -1.7976931348623157e+308 ); 
-
-
-n=0; 
-test( "n=0;<BR>n = 0*Number.MAX_VALUE", n = 0*Number.MAX_VALUE, 0 ); 
-
-
-n=12345; 
-test( "n=12345;<BR>n = 12345*Number.MAX_VALUE", n = 12345*Number.MAX_VALUE, Infinity ); 
-
-
-n=-12345;
-test( "n=-12345;<BR>n = -12345*Number.MAX_VALUE", n = -12345*Number.MAX_VALUE, -Infinity ); 
-
-
-n=0x45ae;
-test( "n=0x45ae;<BR>n = 17838*Number.MAX_VALUE", n = 17838*Number.MAX_VALUE, Infinity ); 
-
-
-n=0; 
-test( "n=0;<BR>n = 0/Number.MAX_VALUE", n = 0/Number.MAX_VALUE, 0 ); 
-
-
-n=12345; 
-test( "n=12345;<BR>n = 12345/Number.MAX_VALUE", n = 12345/Number.MAX_VALUE, 6.867134195817851e-305 ); 
-
-
-n=-12345;
-test( "n=-12345;<BR>n = -12345/Number.MAX_VALUE", n = -12345/Number.MAX_VALUE, -6.867134195817851e-305 ); 
-
-
-n=0x45ae;
-test( "n=0x45ae;<BR>n = 17838/Number.MAX_VALUE", n = 17838/Number.MAX_VALUE, 9.922716872012866e-305 ); 
-
-
-n=0; 
-test( "n=0;<BR>n = 0%Number.MAX_VALUE", n = 0%Number.MAX_VALUE, 0 ); 
-
-
-n=12345; 
-test( "n=12345;<BR>n = 12345%Number.MAX_VALUE", n = 12345%Number.MAX_VALUE, 12345 ); 
-
-
-n=-12345;
-test( "n=-12345;<BR>n = -12345%Number.MAX_VALUE", n = -12345%Number.MAX_VALUE, -12345 ); 
-
-
-n=0x45ae;
-test( "n=0x45ae;<BR>n = 17838%Number.MAX_VALUE", n = 17838%Number.MAX_VALUE, 17838 ); 
+test( "n=0x45ae;<BR>n = 17838+Number.MAX_VALUE", n = 17838+Number.MAX_VALUE, 1.7976931348623157e+308 );
 
 
 n=0;
-test( "n=0;<BR>n +=Number.MAX_VALUE", n +=Number.MAX_VALUE, 1.7976931348623157e+308 ); 
+test( "n=0;<BR>n = 0-Number.MAX_VALUE", n = 0-Number.MAX_VALUE, -1.7976931348623157e+308 );
 
 
-n=12345; 
+n=12345;
+test( "n=12345;<BR>n = 12345-Number.MAX_VALUE", n = 12345-Number.MAX_VALUE, -1.7976931348623157e+308 );
+
+
+n=-12345;
+test( "n=-12345;<BR>n = -12345-Number.MAX_VALUE", n = -12345-Number.MAX_VALUE, -1.7976931348623157e+308 );
+
+
+n=0x45ae;
+test( "n=0x45ae;<BR>n = 17838-Number.MAX_VALUE", n = 17838-Number.MAX_VALUE, -1.7976931348623157e+308 );
+
+
+n=0;
+test( "n=0;<BR>n = 0*Number.MAX_VALUE", n = 0*Number.MAX_VALUE, 0 );
+
+
+n=12345;
+test( "n=12345;<BR>n = 12345*Number.MAX_VALUE", n = 12345*Number.MAX_VALUE, Infinity );
+
+
+n=-12345;
+test( "n=-12345;<BR>n = -12345*Number.MAX_VALUE", n = -12345*Number.MAX_VALUE, -Infinity );
+
+
+n=0x45ae;
+test( "n=0x45ae;<BR>n = 17838*Number.MAX_VALUE", n = 17838*Number.MAX_VALUE, Infinity );
+
+
+n=0;
+test( "n=0;<BR>n = 0/Number.MAX_VALUE", n = 0/Number.MAX_VALUE, 0 );
+
+
+n=12345;
+test( "n=12345;<BR>n = 12345/Number.MAX_VALUE", n = 12345/Number.MAX_VALUE, 6.867134195817851e-305 );
+
+
+n=-12345;
+test( "n=-12345;<BR>n = -12345/Number.MAX_VALUE", n = -12345/Number.MAX_VALUE, -6.867134195817851e-305 );
+
+
+n=0x45ae;
+test( "n=0x45ae;<BR>n = 17838/Number.MAX_VALUE", n = 17838/Number.MAX_VALUE, 9.922716872012866e-305 );
+
+
+n=0;
+test( "n=0;<BR>n = 0%Number.MAX_VALUE", n = 0%Number.MAX_VALUE, 0 );
+
+
+n=12345;
+test( "n=12345;<BR>n = 12345%Number.MAX_VALUE", n = 12345%Number.MAX_VALUE, 12345 );
+
+
+n=-12345;
+test( "n=-12345;<BR>n = -12345%Number.MAX_VALUE", n = -12345%Number.MAX_VALUE, -12345 );
+
+
+n=0x45ae;
+test( "n=0x45ae;<BR>n = 17838%Number.MAX_VALUE", n = 17838%Number.MAX_VALUE, 17838 );
+
+
+n=0;
+test( "n=0;<BR>n +=Number.MAX_VALUE", n +=Number.MAX_VALUE, 1.7976931348623157e+308 );
+
+
+n=12345;
 test( "n=12345;<BR>n +=Number.MAX_VALUE", n +=Number.MAX_VALUE, 1.7976931348623157e+308 );
 
 
@@ -1740,10 +1740,10 @@ test( "n=0x45ae;<BR>n +=Number.MAX_VALUE", n +=Number.MAX_VALUE, 1.7976931348623
 
 
 n=0;
-test( "n=0;<BR>n -=Number.MAX_VALUE", n -=Number.MAX_VALUE, -1.7976931348623157e+308 ); 
+test( "n=0;<BR>n -=Number.MAX_VALUE", n -=Number.MAX_VALUE, -1.7976931348623157e+308 );
 
 
-n=12345; 
+n=12345;
 test( "n=12345;<BR>n -=Number.MAX_VALUE", n -=Number.MAX_VALUE, -1.7976931348623157e+308 );
 
 
@@ -1756,10 +1756,10 @@ test( "n=0x45ae;<BR>n -=Number.MAX_VALUE", n -=Number.MAX_VALUE, -1.797693134862
 
 
 n=0;
-test( "n=0;<BR>n *=Number.MAX_VALUE", n *=Number.MAX_VALUE, 0 ); 
+test( "n=0;<BR>n *=Number.MAX_VALUE", n *=Number.MAX_VALUE, 0 );
 
 
-n=12345; 
+n=12345;
 test( "n=12345;<BR>n *=Number.MAX_VALUE", n *=Number.MAX_VALUE, Infinity );
 
 
@@ -1772,10 +1772,10 @@ test( "n=0x45ae;<BR>n *=Number.MAX_VALUE", n *=Number.MAX_VALUE, Infinity );
 
 
 n=0;
-test( "n=0;<BR>n /=Number.MAX_VALUE", n /=Number.MAX_VALUE, 0 ); 
+test( "n=0;<BR>n /=Number.MAX_VALUE", n /=Number.MAX_VALUE, 0 );
 
 
-n=12345; 
+n=12345;
 test( "n=12345;<BR>n /=Number.MAX_VALUE", n /=Number.MAX_VALUE, 6.867134195817851e-305 );
 
 
@@ -1788,10 +1788,10 @@ test( "n=0x45ae;<BR>n /=Number.MAX_VALUE", n /=Number.MAX_VALUE, 9.9227168720128
 
 
 n=0;
-test( "n=0;<BR>n %=Number.MAX_VALUE", n %=Number.MAX_VALUE, 0 ); 
+test( "n=0;<BR>n %=Number.MAX_VALUE", n %=Number.MAX_VALUE, 0 );
 
 
-n=12345; 
+n=12345;
 test( "n=12345;<BR>n %=Number.MAX_VALUE", n %=Number.MAX_VALUE, 12345 );
 
 
@@ -1803,85 +1803,85 @@ n=0x45ae;
 test( "n=0x45ae;<BR>n %=Number.MAX_VALUE", n %=Number.MAX_VALUE, 17838 );
 
 
-n=0; 
-test( "n=0;<BR>n = 0+Number.MIN_VALUE", n = 0+Number.MIN_VALUE, 5e-324 ); 
+n=0;
+test( "n=0;<BR>n = 0+Number.MIN_VALUE", n = 0+Number.MIN_VALUE, 5e-324 );
 
-n=12345; 
-test( "n=12345;<BR>n = 12345+Number.MIN_VALUE", n = 12345+Number.MIN_VALUE, 12345 ); 
-
-
-n=-12345;
-test( "n=-12345;<BR>n = -12345+Number.MIN_VALUE", n = -12345+Number.MIN_VALUE, -12345 ); 
-
-
-n=0x45ae;
-test( "n=0x45ae;<BR>n = 17838+Number.MIN_VALUE", n = 17838+Number.MIN_VALUE, 17838 ); 
-
-
-n=0; 
-test( "n=0;<BR>n = 0-Number.MIN_VALUE", n = 0-Number.MIN_VALUE, -5e-324 ); 
-
-n=12345; 
-test( "n=12345;<BR>n = 12345-Number.MIN_VALUE", n = 12345-Number.MIN_VALUE, 12345 ); 
+n=12345;
+test( "n=12345;<BR>n = 12345+Number.MIN_VALUE", n = 12345+Number.MIN_VALUE, 12345 );
 
 
 n=-12345;
-test( "n=-12345;<BR>n = -12345-Number.MIN_VALUE", n = -12345-Number.MIN_VALUE, -12345 ); 
+test( "n=-12345;<BR>n = -12345+Number.MIN_VALUE", n = -12345+Number.MIN_VALUE, -12345 );
 
 
 n=0x45ae;
-test( "n=0x45ae;<BR>n = 17838-Number.MIN_VALUE", n = 17838-Number.MIN_VALUE, 17838 ); 
-
-
-n=0; 
-test( "n=0;<BR>n = 0*Number.MIN_VALUE", n = 0*Number.MIN_VALUE, 0 ); 
-
-
-n=12345; 
-test( "n=12345;<BR>n = 12345*Number.MIN_VALUE", n = 12345*Number.MIN_VALUE, 6.099e-320 ); 
-
-n=-12345;
-test( "n=-12345;<BR>n = -12345*Number.MIN_VALUE", n = -12345*Number.MIN_VALUE, -6.099e-320 ); 
-
-n=0x45ae;
-test( "n=0x45ae;<BR>n = 17838*Number.MIN_VALUE", n = 17838*Number.MIN_VALUE, 8.813e-320 ); 
-
-n=0; 
-test( "n=0;<BR>n = 0/Number.MIN_VALUE", n = 0/Number.MIN_VALUE, 0 ); 
-
-
-n=12345; 
-test( "n=12345;<BR>n = 12345/Number.MIN_VALUE", n = 12345/Number.MIN_VALUE, Infinity ); 
-
-
-n=-12345;
-test( "n=-12345;<BR>n = -12345/Number.MIN_VALUE", n = -12345/Number.MIN_VALUE, -Infinity ); 
-
-
-n=0x45ae;
-test( "n=0x45ae;<BR>n = 17838/Number.MIN_VALUE", n = 17838/Number.MIN_VALUE, Infinity ); 
-
-
-n=0; 
-test( "n=0;<BR>n = 0%Number.MIN_VALUE", n = 0%Number.MIN_VALUE, 0 ); 
-
-
-n=12345; 
-test( "n=12345;<BR>n = 12345%Number.MIN_VALUE", n = 12345%Number.MIN_VALUE, 0 ); 
-
-
-n=-12345;
-test( "n=-12345;<BR>n = -12345%Number.MIN_VALUE", n = -12345%Number.MIN_VALUE, 0 ); 
-
-
-n=0x45ae;
-test( "n=0x45ae;<BR>n = 17838%Number.MIN_VALUE", n = 17838%Number.MIN_VALUE, 0 ); 
+test( "n=0x45ae;<BR>n = 17838+Number.MIN_VALUE", n = 17838+Number.MIN_VALUE, 17838 );
 
 
 n=0;
-test( "n=0;<BR>n +=Number.MIN_VALUE", n +=Number.MIN_VALUE, 5e-324 ); 
+test( "n=0;<BR>n = 0-Number.MIN_VALUE", n = 0-Number.MIN_VALUE, -5e-324 );
 
-n=12345; 
+n=12345;
+test( "n=12345;<BR>n = 12345-Number.MIN_VALUE", n = 12345-Number.MIN_VALUE, 12345 );
+
+
+n=-12345;
+test( "n=-12345;<BR>n = -12345-Number.MIN_VALUE", n = -12345-Number.MIN_VALUE, -12345 );
+
+
+n=0x45ae;
+test( "n=0x45ae;<BR>n = 17838-Number.MIN_VALUE", n = 17838-Number.MIN_VALUE, 17838 );
+
+
+n=0;
+test( "n=0;<BR>n = 0*Number.MIN_VALUE", n = 0*Number.MIN_VALUE, 0 );
+
+
+n=12345;
+test( "n=12345;<BR>n = 12345*Number.MIN_VALUE", n = 12345*Number.MIN_VALUE, 6.099e-320 );
+
+n=-12345;
+test( "n=-12345;<BR>n = -12345*Number.MIN_VALUE", n = -12345*Number.MIN_VALUE, -6.099e-320 );
+
+n=0x45ae;
+test( "n=0x45ae;<BR>n = 17838*Number.MIN_VALUE", n = 17838*Number.MIN_VALUE, 8.813e-320 );
+
+n=0;
+test( "n=0;<BR>n = 0/Number.MIN_VALUE", n = 0/Number.MIN_VALUE, 0 );
+
+
+n=12345;
+test( "n=12345;<BR>n = 12345/Number.MIN_VALUE", n = 12345/Number.MIN_VALUE, Infinity );
+
+
+n=-12345;
+test( "n=-12345;<BR>n = -12345/Number.MIN_VALUE", n = -12345/Number.MIN_VALUE, -Infinity );
+
+
+n=0x45ae;
+test( "n=0x45ae;<BR>n = 17838/Number.MIN_VALUE", n = 17838/Number.MIN_VALUE, Infinity );
+
+
+n=0;
+test( "n=0;<BR>n = 0%Number.MIN_VALUE", n = 0%Number.MIN_VALUE, 0 );
+
+
+n=12345;
+test( "n=12345;<BR>n = 12345%Number.MIN_VALUE", n = 12345%Number.MIN_VALUE, 0 );
+
+
+n=-12345;
+test( "n=-12345;<BR>n = -12345%Number.MIN_VALUE", n = -12345%Number.MIN_VALUE, 0 );
+
+
+n=0x45ae;
+test( "n=0x45ae;<BR>n = 17838%Number.MIN_VALUE", n = 17838%Number.MIN_VALUE, 0 );
+
+
+n=0;
+test( "n=0;<BR>n +=Number.MIN_VALUE", n +=Number.MIN_VALUE, 5e-324 );
+
+n=12345;
 test( "n=12345;<BR>n +=Number.MIN_VALUE", n +=Number.MIN_VALUE, 12345 );
 
 
@@ -1894,9 +1894,9 @@ test( "n=0x45ae;<BR>n +=Number.MIN_VALUE", n +=Number.MIN_VALUE, 17838 );
 
 
 n=0;
-test( "n=0;<BR>n -=Number.MIN_VALUE", n -=Number.MIN_VALUE, -5e-324 ); 
+test( "n=0;<BR>n -=Number.MIN_VALUE", n -=Number.MIN_VALUE, -5e-324 );
 
-n=12345; 
+n=12345;
 test( "n=12345;<BR>n -=Number.MIN_VALUE", n -=Number.MIN_VALUE, 12345 );
 
 
@@ -1909,10 +1909,10 @@ test( "n=0x45ae;<BR>n -=Number.MIN_VALUE", n -=Number.MIN_VALUE, 17838 );
 
 
 n=0;
-test( "n=0;<BR>n *=Number.MIN_VALUE", n *=Number.MIN_VALUE, 0 ); 
+test( "n=0;<BR>n *=Number.MIN_VALUE", n *=Number.MIN_VALUE, 0 );
 
 
-n=12345; 
+n=12345;
 test( "n=12345;<BR>n *=Number.MIN_VALUE", n *=Number.MIN_VALUE, 6.099e-320 );
 
 n=-12345;
@@ -1922,10 +1922,10 @@ n=0x45ae;
 test( "n=0x45ae;<BR>n *=Number.MIN_VALUE", n *=Number.MIN_VALUE, 8.813e-320 );
 
 n=0;
-test( "n=0;<BR>n /=Number.MIN_VALUE", n /=Number.MIN_VALUE, 0 ); 
+test( "n=0;<BR>n /=Number.MIN_VALUE", n /=Number.MIN_VALUE, 0 );
 
 
-n=12345; 
+n=12345;
 test( "n=12345;<BR>n /=Number.MIN_VALUE", n /=Number.MIN_VALUE, Infinity );
 
 
@@ -1935,13 +1935,13 @@ test( "n=-12345;<BR>n /=Number.MIN_VALUE", n /=Number.MIN_VALUE, -Infinity );
 
 n=0x45ae;
 test( "n=0x45ae;<BR>n /=Number.MIN_VALUE", n /=Number.MIN_VALUE, Infinity );
- 
+
 
 n=0;
-test( "n=0;<BR>n %=Number.MIN_VALUE", n %=Number.MIN_VALUE, 0 ); 
+test( "n=0;<BR>n %=Number.MIN_VALUE", n %=Number.MIN_VALUE, 0 );
 
 
-n=12345; 
+n=12345;
 test( "n=12345;<BR>n %=Number.MIN_VALUE", n %=Number.MIN_VALUE, 0 );
 
 
@@ -1953,91 +1953,91 @@ n=0x45ae;
 test( "n=0x45ae;<BR>n %=Number.MIN_VALUE", n %=Number.MIN_VALUE, 0 );
 
 
-n=0; 
-test( "n=0;<BR>n = 0+Number.NaN", n = 0+Number.NaN, Number.NaN ); 
+n=0;
+test( "n=0;<BR>n = 0+Number.NaN", n = 0+Number.NaN, Number.NaN );
 
 
-n=12345; 
-test( "n=12345;<BR>n = 12345+Number.NaN", n = 12345+Number.NaN, Number.NaN ); 
-
-
-n=-12345;
-test( "n=-12345;<BR>n = -12345+Number.NaN", n = -12345+Number.NaN, Number.NaN ); 
-
-
-n=0x45ae;
-test( "n=0x45ae;<BR>n = 17838+Number.NaN", n = 17838+Number.NaN, Number.NaN ); 
-
-
-n=0; 
-test( "n=0;<BR>n = 0-Number.NaN", n = 0-Number.NaN, Number.NaN ); 
-
-
-n=12345; 
-test( "n=12345;<BR>n = 12345-Number.NaN", n = 12345-Number.NaN, Number.NaN ); 
+n=12345;
+test( "n=12345;<BR>n = 12345+Number.NaN", n = 12345+Number.NaN, Number.NaN );
 
 
 n=-12345;
-test( "n=-12345;<BR>n = -12345-Number.NaN", n = -12345-Number.NaN, Number.NaN ); 
+test( "n=-12345;<BR>n = -12345+Number.NaN", n = -12345+Number.NaN, Number.NaN );
 
 
 n=0x45ae;
-test( "n=0x45ae;<BR>n = 17838-Number.NaN", n = 17838-Number.NaN, Number.NaN ); 
-
-
-n=0; 
-test( "n=0;<BR>n = 0*Number.NaN", n = 0*Number.NaN, Number.NaN ); 
-
-
-n=12345; 
-test( "n=12345;<BR>n = 12345*Number.NaN", n = 12345*Number.NaN, Number.NaN ); 
-
-
-n=-12345;
-test( "n=-12345;<BR>n = -12345*Number.NaN", n = -12345*Number.NaN, Number.NaN ); 
-
-
-n=0x45ae;
-test( "n=0x45ae;<BR>n = 17838*Number.NaN", n = 17838*Number.NaN, Number.NaN ); 
-
-
-n=0; 
-test( "n=0;<BR>n = 0/Number.NaN", n = 0/Number.NaN, Number.NaN ); 
-
-
-n=12345; 
-test( "n=12345;<BR>n = 12345/Number.NaN", n = 12345/Number.NaN, Number.NaN ); 
-
-
-n=-12345;
-test( "n=-12345;<BR>n = -12345/Number.NaN", n = -12345/Number.NaN, Number.NaN ); 
-
-
-n=0x45ae;
-test( "n=0x45ae;<BR>n = 17838/Number.NaN", n = 17838/Number.NaN, Number.NaN ); 
-
-
-n=0; 
-test( "n=0;<BR>n = 0%Number.NaN", n = 0%Number.NaN, Number.NaN ); 
-
-
-n=12345; 
-test( "n=12345;<BR>n = 12345%Number.NaN", n = 12345%Number.NaN, Number.NaN ); 
-
-
-n=-12345;
-test( "n=-12345;<BR>n = -12345%Number.NaN", n = -12345%Number.NaN, Number.NaN ); 
-
-
-n=0x45ae;
-test( "n=0x45ae;<BR>n = 17838%Number.NaN", n = 17838%Number.NaN, Number.NaN ); 
+test( "n=0x45ae;<BR>n = 17838+Number.NaN", n = 17838+Number.NaN, Number.NaN );
 
 
 n=0;
-test( "n=0;<BR>n +=Number.NaN", n +=Number.NaN, Number.NaN ); 
+test( "n=0;<BR>n = 0-Number.NaN", n = 0-Number.NaN, Number.NaN );
 
 
-n=12345; 
+n=12345;
+test( "n=12345;<BR>n = 12345-Number.NaN", n = 12345-Number.NaN, Number.NaN );
+
+
+n=-12345;
+test( "n=-12345;<BR>n = -12345-Number.NaN", n = -12345-Number.NaN, Number.NaN );
+
+
+n=0x45ae;
+test( "n=0x45ae;<BR>n = 17838-Number.NaN", n = 17838-Number.NaN, Number.NaN );
+
+
+n=0;
+test( "n=0;<BR>n = 0*Number.NaN", n = 0*Number.NaN, Number.NaN );
+
+
+n=12345;
+test( "n=12345;<BR>n = 12345*Number.NaN", n = 12345*Number.NaN, Number.NaN );
+
+
+n=-12345;
+test( "n=-12345;<BR>n = -12345*Number.NaN", n = -12345*Number.NaN, Number.NaN );
+
+
+n=0x45ae;
+test( "n=0x45ae;<BR>n = 17838*Number.NaN", n = 17838*Number.NaN, Number.NaN );
+
+
+n=0;
+test( "n=0;<BR>n = 0/Number.NaN", n = 0/Number.NaN, Number.NaN );
+
+
+n=12345;
+test( "n=12345;<BR>n = 12345/Number.NaN", n = 12345/Number.NaN, Number.NaN );
+
+
+n=-12345;
+test( "n=-12345;<BR>n = -12345/Number.NaN", n = -12345/Number.NaN, Number.NaN );
+
+
+n=0x45ae;
+test( "n=0x45ae;<BR>n = 17838/Number.NaN", n = 17838/Number.NaN, Number.NaN );
+
+
+n=0;
+test( "n=0;<BR>n = 0%Number.NaN", n = 0%Number.NaN, Number.NaN );
+
+
+n=12345;
+test( "n=12345;<BR>n = 12345%Number.NaN", n = 12345%Number.NaN, Number.NaN );
+
+
+n=-12345;
+test( "n=-12345;<BR>n = -12345%Number.NaN", n = -12345%Number.NaN, Number.NaN );
+
+
+n=0x45ae;
+test( "n=0x45ae;<BR>n = 17838%Number.NaN", n = 17838%Number.NaN, Number.NaN );
+
+
+n=0;
+test( "n=0;<BR>n +=Number.NaN", n +=Number.NaN, Number.NaN );
+
+
+n=12345;
 test( "n=12345;<BR>n +=Number.NaN", n +=Number.NaN, Number.NaN );
 
 
@@ -2050,10 +2050,10 @@ test( "n=0x45ae;<BR>n +=Number.NaN", n +=Number.NaN, Number.NaN );
 
 
 n=0;
-test( "n=0;<BR>n -=Number.NaN", n -=Number.NaN, Number.NaN ); 
+test( "n=0;<BR>n -=Number.NaN", n -=Number.NaN, Number.NaN );
 
 
-n=12345; 
+n=12345;
 test( "n=12345;<BR>n -=Number.NaN", n -=Number.NaN, Number.NaN );
 
 
@@ -2066,10 +2066,10 @@ test( "n=0x45ae;<BR>n -=Number.NaN", n -=Number.NaN, Number.NaN );
 
 
 n=0;
-test( "n=0;<BR>n *=Number.NaN", n *=Number.NaN, Number.NaN ); 
+test( "n=0;<BR>n *=Number.NaN", n *=Number.NaN, Number.NaN );
 
 
-n=12345; 
+n=12345;
 test( "n=12345;<BR>n *=Number.NaN", n *=Number.NaN, Number.NaN );
 
 
@@ -2082,10 +2082,10 @@ test( "n=0x45ae;<BR>n *=Number.NaN", n *=Number.NaN, Number.NaN );
 
 
 n=0;
-test( "n=0;<BR>n /=Number.NaN", n /=Number.NaN, Number.NaN ); 
+test( "n=0;<BR>n /=Number.NaN", n /=Number.NaN, Number.NaN );
 
 
-n=12345; 
+n=12345;
 test( "n=12345;<BR>n /=Number.NaN", n /=Number.NaN, Number.NaN );
 
 
@@ -2098,10 +2098,10 @@ test( "n=0x45ae;<BR>n /=Number.NaN", n /=Number.NaN, Number.NaN );
 
 
 n=0;
-test( "n=0;<BR>n %=Number.NaN", n %=Number.NaN, Number.NaN ); 
+test( "n=0;<BR>n %=Number.NaN", n %=Number.NaN, Number.NaN );
 
 
-n=12345; 
+n=12345;
 test( "n=12345;<BR>n %=Number.NaN", n %=Number.NaN, Number.NaN );
 
 

--- a/core/standards/scripts/jstest-core-2/es-regression/scripts/regExpTestES4.js
+++ b/core/standards/scripts/jstest-core-2/es-regression/scripts/regExpTestES4.js
@@ -1,4 +1,4 @@
-/* -*- mode: c++; tab-width: 4; c-file-style: "bsd" -*- 
+/* -*- mode: c++; tab-width: 4; c-file-style: "bsd" -*-
  *
  * Copyright (C) 2001-2002 Opera Software ASA.  All rights reserved.
  *
@@ -10,7 +10,7 @@ var cvs = "$Id: regExpTestES4.js,v 1.1.2.3 2006/08/24 10:26:52 lth Exp $";
 
 function main()
 {
-   try 
+   try
    {
       printHeader( "RegExp ECMAScript 4 testsuite", cvs );
 
@@ -50,7 +50,7 @@ function testECMAScript4()
 		re_test(/abc/y, "012345abc", 5, 0, null);
 		re_test(/a(?P<fisk>b)c/g, "01abc23", 0, 2, ["abc","b"], null, { fisk: "b" } );
 		re_test(/a(?P<fisk>b)c(?P=fisk)d/g, "01abcbd23", 0, 2, ["abcbd","b"], null, { fisk: "b" });
-		re_test(/a(?P<fisk>b)c(?P=fisk)d(?P<fnys>e)/g, "01abcbde23", 0, 2, 
+		re_test(/a(?P<fisk>b)c(?P=fisk)d(?P<fnys>e)/g, "01abcbde23", 0, 2,
 		        ["abcbde","b","e"], null, { fisk: "b", fnys: "e" });
 		test_deep("call regexp", /abc/("xyabcde"), ["abc"] );
 	}

--- a/core/standards/scripts/jstest-core-2/es-regression/scripts/statements.js
+++ b/core/standards/scripts/jstest-core-2/es-regression/scripts/statements.js
@@ -72,21 +72,21 @@ for ( i in myobj )
 for ( i=0 ; i < shouldfind.length ; i++ )
 	test( "found exactly once" + shouldfind[i][0], shouldfind[i][2], 1 );
 
-// Enumerations across 'undefined' supposedly works in Mozilla 1.0 RC1, NS 4.7, and IE 6, but 
+// Enumerations across 'undefined' supposedly works in Mozilla 1.0 RC1, NS 4.7, and IE 6, but
 // is clearly wrong according to the ECMAScript spec
 /* Opera is compatible with major browsers.
 expect_exception( "enumerate undefined", TypeError,
 				  function () { for(i in undefined) showfailure( "undefined has no fields" ); } );
 */
 
-// Enumerations across 'null' supposedly works in Mozilla 1.0 RC1, NS 4.7, and IE 6, but 
+// Enumerations across 'null' supposedly works in Mozilla 1.0 RC1, NS 4.7, and IE 6, but
 // is clearly wrong according to the ECMAScript spec
 /* Opera is compatible with major browsers.
 expect_exception( "enumerate null", TypeError,
 				  function () { for(i in null) showfailure( "null has no fields" ); } );
 */
 
-// Regression, picked up from syntax.js 
+// Regression, picked up from syntax.js
 // The problem is the for ( var ... in ... ), so don't change this to for ( ... in ... )
 
 var x = new Object();
@@ -116,8 +116,8 @@ for ( i in document.getElementById("yow") )
 var shows = new Array();
 shows['hej'] = 'hå';
 var x=0;
-for ( i in shows ) 
-  if (shows[i] == 'hå') 
+for ( i in shows )
+  if (shows[i] == 'hå')
     x++;
 test( "Regression from Martin #1", x, 1 );
 test( "Regression from Martin #2", shows.length, 0 );
@@ -135,7 +135,7 @@ for ( i in theMenu )
 testcase( "break turns into return" );
 
 // This catches a problem internally in the engine where break was
-// not handled properly.  
+// not handled properly.
 
 var break_is_broken_v = 10;
 function break_is_broken()
@@ -168,14 +168,14 @@ test( "regression 1", break_is_broken_v, 100 );
 testcase( "for-in regressions" );
 
 var s='';
-for(a in this) 
+for(a in this)
   s+='\n'+a;
 
 test( "for-in regression #156753", s.indexOf('.'), -1 ); // No .Txxxxxxx variables in the global scope
 
-var ar = new Object; 
-ar["aa"] = "aa"; 
-ar["4444555566662222"] = "xx"; 
+var ar = new Object;
+ar["aa"] = "aa";
+ar["4444555566662222"] = "xx";
 var s = "";
 for (var i in ar)
 	s = s + i;

--- a/core/standards/scripts/jstest-core-2/js-regression/scripts/js_anchor.js
+++ b/core/standards/scripts/jstest-core-2/js-regression/scripts/js_anchor.js
@@ -45,7 +45,7 @@ test( 'text #0', typeof(a1.text), "string" );
 test( 'text #1', typeof(a3.text), "string" );
 test( 'text #2', a1.text, "Anchor 1" );
 // the test failed in Opera without the removeWhiteSpace().
-test( 'text #3', removeWhiteSpace( a3.text ), "" ); 
+test( 'text #3', removeWhiteSpace( a3.text ), "" );
 
 // added by torstein
 testcase( "changing property values" );

--- a/core/standards/scripts/jstest-core-2/js-regression/scripts/js_button.js
+++ b/core/standards/scripts/jstest-core-2/js-regression/scripts/js_button.js
@@ -8,11 +8,11 @@ var tprop;
 
 function main( buttonObject )
 {
-   try 
+   try
    {
       var cvs = "$Id: js_button.js 4838 2006-01-18 05:59:01Z hallvord $";
       testmodule( "The Button object", cvs );
-      
+
       this.tprop = make_tprop( document.theform );
       tprop( "thebutton", "object" );
 
@@ -38,7 +38,7 @@ function main( buttonObject )
    testmodule_finished();
 
 }
-      
+
 
 function testButtonProperties( button )
 {
@@ -46,7 +46,7 @@ function testButtonProperties( button )
    tprop( "name", "string" );
    tprop( "type", "string" );
    tprop( "value", "string" );
-   
+
    test( "form", button.form, document.theform );
    test( "name", button.name, "thebutton" );
    test( "type", button.type, "button" );
@@ -61,7 +61,7 @@ function testButtonProperties( button )
    test( "modified value", button.value, "beta");
 
    button.type = "button";
-   
+
    expect_DOM_exception( "Changing a readonly value, button.form",
                          dom_no_modification_allowed_err,
                          function() { button.form = "something"; } );

--- a/core/standards/scripts/jstest-core-2/js-regression/scripts/js_checkbox.js
+++ b/core/standards/scripts/jstest-core-2/js-regression/scripts/js_checkbox.js
@@ -11,11 +11,11 @@ var tprop;
 
 function main( checkboxObject )
 {
-   try 
+   try
    {
       var cvs = "$Id: js_checkbox.js 4838 2006-01-18 05:59:01Z hallvord $";
       testmodule( "The Checkbox object", cvs );
-      
+
       this.tprop = make_tprop( document.theform );
       tprop( "thecheckbox", "object" );
 
@@ -40,7 +40,7 @@ function main( checkboxObject )
 
    testmodule_finished();
 }
-    
+
 function testCheckboxProperties( checkbox )
 {
    tprop( "defaultChecked", "boolean" );
@@ -49,7 +49,7 @@ function testCheckboxProperties( checkbox )
    tprop( "name", "string" );
    tprop( "type", "string" );
    tprop( "value", "string" );
-   
+
    test( "defaultChecked", checkbox.defaultChecked, true);
    test_s( "checked", checkbox.checked, true);
    test( "form", checkbox.form, document.theform );

--- a/core/standards/scripts/jstest-core-2/js-regression/scripts/js_fileupload.js
+++ b/core/standards/scripts/jstest-core-2/js-regression/scripts/js_fileupload.js
@@ -10,11 +10,11 @@ var tprop;
 
 function main( fileuploadObject )
 {
-   try 
+   try
    {
       var cvs = "$Id: js_fileupload.js 4838 2006-01-18 05:59:01Z hallvord $";
       testmodule( "The FileUpload object", cvs );
-      
+
       this.tprop = make_tprop( document.theform );
       tprop( "thefile", "object" );
 
@@ -39,14 +39,14 @@ function main( fileuploadObject )
 
    testmodule_finished();
 }
-    
+
 function testFileUploadProperties( file )
 {
    tprop( "form", "object" );
    tprop( "name", "string" );
    tprop( "type", "string" );
    tprop( "value", "string" );
-   
+
    test( "form", file.form, document.theform );
    test( "name", file.name, "thefile" );
    test( "type", file.type, "file" );

--- a/core/standards/scripts/jstest-core-2/js-regression/scripts/js_form.js
+++ b/core/standards/scripts/jstest-core-2/js-regression/scripts/js_form.js
@@ -10,11 +10,11 @@ var tprop;
 
 function main( formObject )
 {
-   try 
+   try
    {
       var cvs = "$Id";
       testmodule( "The Form object", cvs );
-      
+
       this.tprop = make_tprop( document.theform );
       tprop( "thetext", "object" );
 
@@ -49,7 +49,7 @@ function testFormProperties( form )
    tprop( "method", "string" );
    tprop( "name", "string" );
    tprop( "target", "string" );
-   
+
    test( "action", form.action, "http://davis.intern.opera.no/my_repository/js-regression/js_form.htm");
    test( "elements", form.elements, "[object HTMLCollection]");
    test( "length", form.length, 1 );

--- a/core/standards/scripts/jstest-core-2/js-regression/scripts/js_image.js
+++ b/core/standards/scripts/jstest-core-2/js-regression/scripts/js_image.js
@@ -11,7 +11,7 @@ var imageArray;
 
 function main( imageArray )
 {
-   try 
+   try
    {
       var cvs = "$Id: js_image.js 4838 2006-01-18 05:59:01Z hallvord $";
       testmodule( "The Image object", cvs );
@@ -48,7 +48,7 @@ function main( imageArray )
       {
          exception( e );
       }
-      
+
       testcase( "Image constructor with width" );
       var anothernewimage = Image( "20" );
       anothernewimage.height = 2;
@@ -82,7 +82,7 @@ function testImageConstructor( imageObject )
    {
       test( 'toString', imageObject, "[object HTMLImageElement]" );
    }
-   
+
    imageObject.hspace = 2;
    imageObject.vspace = 10;
    imageObject.border = 1;
@@ -104,9 +104,9 @@ function testImageProperties( image )
 
    if( is_phase( 2 ) )
       tprop( "lowsrc", "string" );
-   
+
    tprop( "name", "string" );
-   
+
    tprop( "src", "string" );
    tprop( "width", "number" );
 
@@ -118,7 +118,7 @@ function testImageProperties( image )
    {
       test( "lowsrc", image.lowsrc, "http://www.opera.com/graphics/company/gallery/ledergruppe.jpg" );
    }
-   
+
    test( "name", image.name, "mypicture" );
    test( "src", image.src, "http://www.opera.com/graphics/logo_z.gif" );
 
@@ -138,7 +138,7 @@ function testImageProperties( image )
    image.hspace = 1;
    image.vspace = 1;
    image.name ="new name";
-   
+
    test( "changing image.border", image.border, 2 );
    test( "changing image.width", image.width, 1 );
    test( "changing image.height", image.height, 1 );

--- a/core/standards/scripts/jstest-core-2/js-regression/scripts/js_mimetype.js
+++ b/core/standards/scripts/jstest-core-2/js-regression/scripts/js_mimetype.js
@@ -8,7 +8,7 @@ var tprop;
 
 function main( windowObject )
 {
-   try 
+   try
    {
       var cvs = "$Id: js_mimetype.js 4838 2006-01-18 05:59:01Z hallvord $";
       testmodule( "The MimeType object", cvs );
@@ -59,21 +59,21 @@ function main( windowObject )
       }
 
       testcase( "MimeType object properties" );
-      test( "type different from description", 
-                           navigator.mimeTypes[ 10 ].type == navigator.mimeTypes[ 10 ].description, 
+      test( "type different from description",
+                           navigator.mimeTypes[ 10 ].type == navigator.mimeTypes[ 10 ].description,
 			   false );
-                           
+
       testcase( 'Standard way of accessing the mimetype properties' );
 
       try
       {
          test( "navigator.mimeTypes[\"image/jpeg\"].type", navigator.mimeTypes["image/jpeg"].type, "image/jpeg" );
-         test_expect_failure( "navigator.mimeTypes[\"image/jpeg\"].description", 
+         test_expect_failure( "navigator.mimeTypes[\"image/jpeg\"].description",
 	       86238,
-	       navigator.mimeTypes["image/jpeg"].description, 
+	       navigator.mimeTypes["image/jpeg"].description,
 	       "JPEG Image" );
 	 var suff = navigator.mimeTypes["image/jpeg"].suffixes;
-         test( "navigator.mimeTypes[\"image/jpeg\"].suffixes", 
+         test( "navigator.mimeTypes[\"image/jpeg\"].suffixes",
 	       suff.indexOf("jpeg") > -1 && suff.indexOf("jpg") > -1 && suff.indexOf("jpe") > -1,
                true );
 

--- a/core/standards/scripts/jstest-core-2/js-regression/scripts/js_option.js
+++ b/core/standards/scripts/jstest-core-2/js-regression/scripts/js_option.js
@@ -12,7 +12,7 @@ var fullconstructorused = false;
 
 function main( selectObject )
 {
-   try 
+   try
    {
       var cvs = "$Id: js_option.js 4838 2006-01-18 05:59:01Z hallvord $";
       testmodule( "The Option object", cvs );
@@ -23,7 +23,7 @@ function main( selectObject )
       this.tprop = make_tprop( optionObject );
 
       tdef( 'option defined', optionObject );
-   
+
       testcase( "toString" );
 
       if( isExplorer() )
@@ -84,7 +84,7 @@ function testOptionConstructor( optionObject )
    {
       test( 'toString',  optionObject, "[object HTMLOptionElement]" );
    }
-   
+
    if( optionObject.value != "" )
    {
       testOptionProperties( optionObject );
@@ -112,7 +112,7 @@ function testOptionProperties( option )
       tprop( "length", "number" ); // bug #82454
       expect_exception( "Changing read-only value, option.length", Error, function() { option.length = 0; } );
    }
-   
+
    test( "defaultSelected", option.defaultSelected, false );
    test( "selected", option.selected, false );
    test( "text", option.text, "My option text" );
@@ -121,11 +121,11 @@ function testOptionProperties( option )
    option.selected = true;
    option.defaultSelected = true;
    option.value = "New option value";
-   
+
    if( this.fullconstructorused )
    {
-      test_expect_failure( "modified selected", "80987", 
-                           option.selected, true, 
+      test_expect_failure( "modified selected", "80987",
+                           option.selected, true,
                            "Failure only occurs when creating an option object using the full constructor." );
 
       this.fullconstructorused = false;
@@ -134,7 +134,7 @@ function testOptionProperties( option )
    {
       test( "modified selected", option.selected, true );
    }
-   
+
    test( "modified defaultSelected", option.defaultSelected, true );
    test( "modified value", option.value, "New option value" );
 

--- a/core/standards/scripts/jstest-core-2/js-regression/scripts/js_plugin.js
+++ b/core/standards/scripts/jstest-core-2/js-regression/scripts/js_plugin.js
@@ -10,7 +10,7 @@ var tprop;
 
 function main( pluginsArray )
 {
-   try 
+   try
    {
       var cvs = "$Id: js_plugin.js 4838 2006-01-18 05:59:01Z hallvord $";
       testmodule( "The Plugin object", cvs );
@@ -28,12 +28,12 @@ function main( pluginsArray )
       for( var i = 0; i < pluginsArray.length; i++ )
       {
          var pluginObject = pluginsArray[ i ];
-         
+
          for( var j = 0; j < pluginObject; j++ )
          {
             test( "pluginObject[ j ] toString", pluginObject[ j ], "[object MimeType]" );
          }
-         
+
          this.tprop = make_tprop( pluginObject );
 
          testcase( "toString" );
@@ -51,7 +51,7 @@ function main( pluginsArray )
    {
       exception( e );
    }
-      
+
    testmodule_finished();
 }
 
@@ -61,7 +61,7 @@ function testPluginProperties( plugin )
    tprop( "filename", "string" );
    tprop( "length", "number" );
    tprop( "name", "string" );
-   
+
    expect_exception( "Changing a readonly value, plugin.description", Error, function() { plugin.description = "something"; } );
    expect_exception( "Changing a readonly value, plugin.filename", Error, function() { plugin.filename = "something"; } );
    expect_exception( "Changing a readonly value, plugin.length", Error, function() { plugin.length = "something"; } );

--- a/core/standards/scripts/jstest-core-2/js-regression/scripts/js_radio.js
+++ b/core/standards/scripts/jstest-core-2/js-regression/scripts/js_radio.js
@@ -10,7 +10,7 @@ var tprop;
 
 function main( radioObject )
 {
-   try 
+   try
    {
       var cvs = "$Id: js_radio.js 4838 2006-01-18 05:59:01Z hallvord $";
       testmodule( "The Radio object", cvs );
@@ -22,7 +22,7 @@ function main( radioObject )
 
       testcase( 'Radio object properties' );
       testRadioProperties( radioObject );
- 
+
       testcase( 'Radio object methods' );
       testRadioMethods( radioObject );
 
@@ -48,7 +48,7 @@ function testRadioProperties( radio )
    tprop( "name", "string" );
    tprop( "type", "string" );
    tprop( "value", "string" );
-   
+
    test( "defaultChecked", radio.defaultChecked, false );
    test( "checked", radio.checked, false );
    test( "form", radio.form, document.theform );
@@ -62,7 +62,7 @@ function testRadioProperties( radio )
 
    test( "modified defaultChecked", radio.defaultChecked, true );
    test_s( "modified checked", radio.checked, true );
-   test( "modified value", radio.value, "New Radio value" ); 
+   test( "modified value", radio.value, "New Radio value" );
 
    radio.defaultChecked = false;
    radio.form.reset();

--- a/core/standards/scripts/jstest-core-2/js-regression/scripts/js_select.js
+++ b/core/standards/scripts/jstest-core-2/js-regression/scripts/js_select.js
@@ -10,7 +10,7 @@ var tprop;
 
 function main( selectObject )
 {
-   try 
+   try
    {
       var cvs = "$Id: js_select.js 4838 2006-01-18 05:59:01Z hallvord $";
       testmodule( "The Select object", cvs );
@@ -22,7 +22,7 @@ function main( selectObject )
 
       testcase( 'Select object properties' );
       testSelectProperties( selectObject );
- 
+
       testcase( 'Select object methods' );
       testSelectMethods( selectObject );
 
@@ -46,12 +46,12 @@ function testSelectProperties( select )
    tprop( "length", "number" );
    tprop( "name", "string" );
    tprop( "type", "string" );
-   tprop( "options", "function" ); 
+   tprop( "options", "function" );
    tprop( "selectedIndex", "number" );
    tprop( "type", "string" );
-   
+
    test( "form", select.form, document.theform );
-   test( "length", select.length, 2 ); 
+   test( "length", select.length, 2 );
    test( "name", select.name, "theselect" );
 
    test( "type", document.theform.theselect.type, "select-one" );
@@ -76,7 +76,7 @@ function testSelectProperties( select )
    {
       exception( e );
    }
-   
+
    test( "selectedIndex", select.selectedIndex, 0 );
 
    select.selectedIndex = 1;
@@ -84,7 +84,7 @@ function testSelectProperties( select )
 
    select.selectedIndex = -1;
    test( "setting selectedIndex to -1", select.selectedIndex, -1, 86240 );
-   
+
 
    /* In ECMAScript, indices are always nonnegative, and negative indices are
       just names, so this is just select.options[ "-1" ], and there is nothing
@@ -105,7 +105,7 @@ function testSelectProperties( select )
 
    select.length = 0;
    select.name = "New Select name";
-   
+
    test( "Modified select.length", select.length, 0 );
    test( "Modified select.name", select.name, "New Select name" );
 }
@@ -114,7 +114,7 @@ function testSelectMethods( select )
 {
    tprop( "blur", "function" );
    tprop( "focus", "function" );
-   
+
    if( is_phase( 2 ) )
    {
       tprop( "handleEvent", "function" );

--- a/core/standards/scripts/jstest-core-2/js-regression/scripts/js_window.js
+++ b/core/standards/scripts/jstest-core-2/js-regression/scripts/js_window.js
@@ -13,7 +13,7 @@ function main( windowObject )
    var cvs = "$Id: js_window.js 4838 2006-01-18 05:59:01Z hallvord $";
    testmodule( "The Window object", cvs );
 
-   try 
+   try
    {
       this.tprop = make_tprop( windowObject );
 
@@ -67,7 +67,7 @@ function testWindowConstructor( win )
    var status = "yes";
    var toolbar = "yes";
 
-   this.newwin = win.open( "", win_name, 
+   this.newwin = win.open( "", win_name,
                            "width=" + inner_width + "," +
                            "height=" + inner_height + "," +
                            "left=" + screen_x + "," +
@@ -168,7 +168,7 @@ function testWindowProperties( win )
       tprop( "statusbar", "object" );
       tprop( "toolbar", "object" );
    }
-   
+
    tprop( "name", "string" );
    tprop( "opener", "object" );
    tprop( "pageXOffset", "number" );
@@ -204,12 +204,12 @@ function testWindowProperties( win )
    {
       exception( e, "Replacing the document object of a window object" );
    }
-   
+
    try
    {
       win.history = null;
       test( "setting win.history to null", win.history, null );
-   }   
+   }
    catch( e )
    {
       exception( e, "Replacing the history object of a window object" );
@@ -225,20 +225,20 @@ function testWindowProperties( win )
       win.offscreenBuffering = false;
       test( "setting offscreenBuffering to false", win.offscreenBuffering, false );
    }
-   
-   test_s( "win.parent", win.parent, self ); 
+
+   test_s( "win.parent", win.parent, self );
    test_s( "self", self, win );
 
    win.status = "";
    test( "win.status", win.status, "" );
    win.status = "new status";
    test( "change win.status", win.status, "new status" );
-   
+
    test_s( "win.top", win.top, self );
    test( "win.top toString", String (win.top), "[object Window]" );
    test( "typeof win.top", typeof win.top + "", "object" );
 
-   test( "window", window, self ); 
+   test( "window", window, self );
 
 }
 
@@ -257,11 +257,11 @@ function testWindowToolbars( win, initialState )
      ( the initial visible test would fail otherwise ).
     */
 
-   if( win.locationbar != undefined ) 
+   if( win.locationbar != undefined )
    {
       test( "win.locationbar toString", win.locationbar + "", "[object BarProp]" );
       test( "win.locationbar.visible", win.locationbar.visible, initialState );
-      
+
       win.locationbar.visible = !initialState;
       test( "changing win.locationbar.visible", win.locationbar.visible, !initialState );
       win.locationbar.visible = initialState;
@@ -331,7 +331,7 @@ function testWindowObjectSpecificProperties( win )
 
    var winlocation = win.location + "";
    winlocation = winlocation.substr( winlocation.lastIndexOf( "/" ) + 1 );
-   test( "win.location", winlocation, "js_window.html" ); 
+   test( "win.location", winlocation, "js_window.html" );
 
    if (win.opener)
 	test_expect_failure( "win.opener", 85168, win.opener, "[object Window]" );
@@ -366,7 +366,7 @@ function testWindowMethods( win )
    if( is_phase( 2 ) )
    {
       tprop( "atob", "function" ); // base-64 en/decoding, #81155
-      tprop( "btoa", "function" ); // base-64 en/decoding, #81155 
+      tprop( "btoa", "function" ); // base-64 en/decoding, #81155
       tprop( "find", "function" );
       tprop( "handleEvent", "function" );
       tprop( "routeEvent", "function" );
@@ -374,7 +374,7 @@ function testWindowMethods( win )
       tprop( "setResizable", "function" ); // #81143
       tprop( "setZOptions", "function" ); // #81144
    }
-   
+
    tprop( "home", "function" );
    tprop( "moveBy", "function" );
    tprop( "moveTo", "function" );
@@ -386,7 +386,7 @@ function testWindowMethods( win )
    tprop( "scroll", "function" );
    tprop( "scrollBy", "function" );
    tprop( "scrollTo", "function" );
-   tprop( "setInterval", "function" ); 
+   tprop( "setInterval", "function" );
    tprop( "setTimeout", "function" );
    tprop( "stop", "function" );
 
@@ -398,7 +398,7 @@ function testWindowMethods( win )
    win.moveBy( 10, 5 );
    test( "moveBy", win.screenX, ( oldx + 10 ) );
    test( "moveBy", win.screenY, ( oldy + 5 ) );
-   
+
    win.moveTo( 20, 30 );
    test( "moveTo, screenX", win.screenX, 20, "81169" );
    test( "moveTo, screenY", win.screenY, 30, "81169" );
@@ -406,14 +406,14 @@ function testWindowMethods( win )
    win.resizeBy( 10, 10 );
    test( "resizeBy, outerWidth", win.outerWidth, ( oldwidth + 10 ) );
    test( "resizeBy, outerHeight", win.outerHeight, ( oldheight + 10 ) );
-   
+
    win.resizeTo( 200, 300 );
    test( "resizeTo, outerWidth", win.outerWidth, 200 );
    test( "resizeTo, outerHeight", win.outerHeight, 300 );
-   
+
    win.resizeTo( oldwidth, oldheight );
    win.moveTo( oldx, oldy );
-}   
+}
 
 function getBoolean( s )
 {

--- a/core/standards/scripts/jstest-core-2/testconfig.js
+++ b/core/standards/scripts/jstest-core-2/testconfig.js
@@ -42,7 +42,7 @@ function get_base()
 
 function get_host()
 {
-    var ph=get_protocol_and_host(); 
+    var ph=get_protocol_and_host();
     var x=ph.lastIndexOf(":");
     var y=ph.indexOf(":");
     return ph.substring( ph.indexOf("//")+2, x != y ? x : ph.length );
@@ -78,7 +78,7 @@ function get_pixel_depth()   { return $$pixel_depth; }
 
 // Returns screen height when ornaments removed
 
-function get_avail_height() 
+function get_avail_height()
 {
   if($$platform == "Win32")
   {
@@ -87,7 +87,7 @@ function get_avail_height()
   return $$screen_height;
 }
 
-function get_avail_width() 
+function get_avail_width()
 {
   return $$screen_width;
 }

--- a/core/standards/scripts/jstest-core-2/userjs/user.js
+++ b/core/standards/scripts/jstest-core-2/userjs/user.js
@@ -47,7 +47,7 @@ opera.addEventListener( 'AfterScript', function(e){
 var beforeExternalScriptFunctionRan=false, beforeExternalScriptFunctionArgumentsOK=false,  beforeExternalScriptFunctionWasRemoved=true;
 opera.addEventListener( 'BeforeExternalScript', function(e){ 
 	beforeExternalScriptFunctionRan=true;
-	if(e && e.element){ 
+	if(e && e.element){
 		if(e.element==document.getElementsByTagName('script')[2] && e.element.text=='' ){
 			beforeExternalScriptFunctionArgumentsOK=true;
 		}else{


### PR DESCRIPTION
It has already been removed from the equivalent files under jstest-futhark.
This makes it easier to compare the two versions of those tests.